### PR TITLE
Fix NilAccept.best_match() so an empty "offers" + default_match picks def

### DIFF
--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -208,11 +208,11 @@ def test_nil_best_match():
     assert nilaccept.best_match([('foo', 1), ('bar', 0.5)]) == 'foo'
     assert nilaccept.best_match([('foo', 0.5), ('bar', 1)]) == 'bar'
     assert nilaccept.best_match([('foo', 0.5), 'bar']) == 'bar'
-    # default_match has no effect on NilAccept class
     assert nilaccept.best_match([('foo', 0.5), 'bar'],
                                 default_match=True) == 'bar'
     assert nilaccept.best_match([('foo', 0.5), 'bar'],
                                 default_match=False) == 'bar'
+    assert nilaccept.best_match([], default_match='fallback') == 'fallback'
 
 
 # NoAccept tests

--- a/webob/acceptparse.py
+++ b/webob/acceptparse.py
@@ -224,7 +224,7 @@ class NilAccept(object):
 
     def best_match(self, offers, default_match=None):
         best_quality = -1
-        best_match = default_match
+        best_offer = default_match
         for offer in offers:
             _check_offer(offer)
             if isinstance(offer, (list, tuple)):


### PR DESCRIPTION
Fix NilAccept.best_match() so an empty "offers" + default_match picks default

Prior to this, NilAccept.best_match([], default_match="default") threw:
UnboundLocalError: local variable 'best_offer' referenced before assignment

Also added a relevant test.
