### PR TITLE
Allow use of arbitrary HTTP status codes in Response

### DIFF
--- a/webob/response.py
+++ b/webob/response.py
@@ -55,7 +55,7 @@ from webob.descriptors import (
 
 from webob.headers import ResponseHeaders
 from webob.request import BaseRequest
-from webob.util import status_reasons
+from webob.util import status_reasons, status_generic_reasons
 
 __all__ = ['Response']
 
@@ -242,7 +242,10 @@ class Response(object):
                 "You must set status to a string or integer (not %s)"
                 % type(value))
         if ' ' not in value:
-            value += ' ' + status_reasons[int(value)]
+             try:
+                value += ' ' + status_reasons[int(value)]
+             except KeyError:
+                value += ' ' + status_generic_reasons[int(value) / 100]
         self._status = value
 
     status = property(_status__get, _status__set, doc=_status__get.__doc__)
@@ -253,7 +256,11 @@ class Response(object):
         """
         return int(self._status.split()[0])
     def _status_int__set(self, code):
-        self._status = '%d %s' % (code, status_reasons[code])
+         try:
+            self._status = '%d %s' % (code, status_reasons[code])
+         except KeyError:
+            self._status = '%d %s' % (code, status_generic_reasons[code / 100])
+
     status_int = property(_status_int__get, _status_int__set,
                           doc=_status_int__get.__doc__)
 

--- a/webob/util.py
+++ b/webob/util.py
@@ -105,6 +105,7 @@ status_reasons = {
     415: 'Unsupported Media Type',
     416: 'Requested Range Not Satisfiable',
     417: 'Expectation Failed',
+    418: "I'm a teapot",
     422: 'Unprocessable Entity',
     423: 'Locked',
     424: 'Failed Dependency',
@@ -121,3 +122,11 @@ status_reasons = {
     510: 'Not Extended',
 }
 
+# generic class responses as per RFC2616
+status_generic_reasons = {
+    1: 'Continue',
+    2: 'Success',
+    3: 'Multiple Choices',
+    4: 'Unknown Client Error',
+    5: 'Unknown Server Error',
+}


### PR DESCRIPTION
Improving compliance with RFC2616 re: HTTP status codes - now an application can provide an arbitrary code, and a generic message (based on the x00 code in the same class) will be generated, rather than raising KeyError.
