### PR TITLE
Fix a dead link

### DIFF
--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -940,7 +940,7 @@ request will an HTML response be given:
 
 
 This is taken from `paste.httpexceptions
-<http://pythonpaste.org/module-paste.httpexceptions.html>`_, and if
+<http://pythonpaste.org/modules/httpexceptions.html#module-paste.httpexceptions>`_, and if
 you have Paste installed then these exceptions will be subclasses of
 the Paste exceptions.
 


### PR DESCRIPTION
The current documentation have a dead link to the paste project, when it comes to describe the http exception that can be raised. This commit fix this.
