### PR TITLE
New webob.static module to serve static file

### DIFF
--- a/webob/static.py
+++ b/webob/static.py
@@ -7,6 +7,7 @@ import zipfile
 from pkg_resources import resource_string, resource_exists, resource_isdir
 
 from webob import exc
+from webob.compat import bytes_
 from webob.dec import wsgify
 from webob.response import Response
 
@@ -92,7 +93,7 @@ class FileApp(object):
 
         try:
             file = open(self.filename, 'rb')
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             msg = "You are not permitted to view this file (%s)" % e
             return exc.HTTPForbidden(msg)
         return DataApp(


### PR DESCRIPTION
This is to fix #33.

As the discussion suggested there, I imported the code from pasteob and changed it slightly so that it works without any pasteob dependencies.
I also imported the tests there, did the same kind of update and made them run under Python 3.2.

The coverage for the module is only 58%, so that still need to be improved before merging I believe.
