### PR TITLE
Make .json/.json_body better

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -21,7 +21,7 @@ class TestRequestCommon(unittest.TestCase):
     def _getTargetClass(self):
         from webob.request import Request
         return Request
-        
+
     def _makeOne(self, *arg, **kw):
         cls = self._getTargetClass()
         return cls(*arg, **kw)
@@ -869,13 +869,13 @@ class TestRequestCommon(unittest.TestCase):
             self.assertEqual(req.as_string(skip_body=337), req.as_string())
             body = req.as_string(337-1).split(b'\r\n\r\n', 1)[1]
             self.assertEqual(body, b'<body skipped (len=337)>')
-    
+
 class TestBaseRequest(unittest.TestCase):
     # tests of methods of a base request which are encoding-specific
     def _getTargetClass(self):
         from webob.request import BaseRequest
         return BaseRequest
-        
+
     def _makeOne(self, *arg, **kw):
         cls = self._getTargetClass()
         return cls(*arg, **kw)
@@ -1519,6 +1519,8 @@ class TestBaseRequest(unittest.TestCase):
         inst = self._makeOne({})
         inst.body = b'{"a":"1"}'
         self.assertEqual(inst.json_body, {'a':'1'})
+        inst.json_body = {'a': '2'}
+        self.assertEqual(inst.body, b'{"a":"2"}')
 
     def test_host_get(self):
         inst = self._makeOne({'HTTP_HOST':'example.com'})
@@ -1537,7 +1539,7 @@ class TestLegacyRequest(unittest.TestCase):
     def _getTargetClass(self):
         from webob.request import LegacyRequest
         return LegacyRequest
-        
+
     def _makeOne(self, *arg, **kw):
         cls = self._getTargetClass()
         return cls(*arg, **kw)
@@ -2200,7 +2202,7 @@ class TestRequestConstructorWarnings(unittest.TestCase):
     def _getTargetClass(self):
         from webob.request import Request
         return Request
-        
+
     def _makeOne(self, *arg, **kw):
         cls = self._getTargetClass()
         return cls(*arg, **kw)
@@ -2256,7 +2258,7 @@ class TestRequest_functional(unittest.TestCase):
     def _getTargetClass(self):
         from webob.request import Request
         return Request
-    
+
     def _makeOne(self, *arg, **kw):
         cls = self._getTargetClass()
         return cls(*arg, **kw)
@@ -3441,4 +3443,3 @@ class UnseekableInput(object):
 class UnseekableInputWithSeek(UnseekableInput):
     def seek(self, pos, rel=0):
         raise IOError("Invalid seek!")
-

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1008,3 +1008,10 @@ def test_response_set_body_file2():
     r = Response(body_file=file)
     assert r.body == data
 
+def test_response_json_body():
+    r = Response(json_body={'a': 1})
+    assert r.body == b'{"a":1}', repr(r.body)
+    assert r.content_type == 'application/json'
+    r = Response()
+    r.json_body = {"b": 1}
+    assert r.content_type == 'text/html'

--- a/webob/request.py
+++ b/webob/request.py
@@ -692,9 +692,17 @@ class BaseRequest(object):
         self.body = b''
     body = property(_body__get, _body__set, _body__del, doc=_body__get.__doc__)
 
-    @property
-    def json_body(self):
+    def _json_body__get(self):
+        """Access the body of the request as JSON"""
         return json.loads(self.body.decode(self.charset))
+
+    def _json_body__set(self, value):
+        self.body = json.dumps(value, separators=(',', ':')).encode(self.charset)
+
+    def _json_body__del(self):
+        del self.body
+
+    json = json_body = property(_json_body__get, _json_body__set, _json_body__del)
 
     @property
     def POST(self):
@@ -1312,7 +1320,7 @@ class BaseRequest(object):
 class LegacyRequest(BaseRequest):
     uscript_name = upath_property('SCRIPT_NAME')
     upath_info = upath_property('PATH_INFO')
-    
+
     def encget(self, key, default=NoDefault, encattr=None):
         val = self.environ.get(key, default)
         if val is NoDefault:


### PR DESCRIPTION
This makes .json (a nicer, shorter name for .json_body) settable, and present on the response.
