### PR TITLE
New static module

### DIFF
--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -136,6 +136,13 @@ class TestFileIter(unittest.TestCase):
         self.assertEqual(bytes_("23456789"), next(i))
         self.assertRaises(StopIteration, next, i)
 
+    def test_limit_is_zero(self):
+        fp = BytesIO(bytes_("0123456789"))
+        i = static.FileIter(fp).app_iter_range(limit=0)
+
+        self.assertRaises(StopIteration, next, i)
+
+
 
 class TestDirectoryApp(unittest.TestCase):
     def setUp(self):

--- a/webob/static.py
+++ b/webob/static.py
@@ -73,17 +73,19 @@ class FileIter(object):
 
         if seek:
             self.file.seek(seek)
-            if limit:
+            if limit is not None:
                 limit -= seek
         try:
             while True:
-                data = self.file.read(min(block_size, limit) if limit else block_size)
+                data = self.file.read(min(block_size, limit)
+                                      if limit is not None
+                                      else block_size)
                 if not data:
                     return
                 yield data
-                if limit:
+                if limit is not None:
                     limit -= len(data)
-                    if not limit:
+                    if limit <= 0:
                         return
         finally:
             self.file.close()


### PR DESCRIPTION
This provides a `webob.static` module to serve static files efficiently. It's an updated copy of `pasteob.static`, cleaned up and with a better test coverage.

It serves as a direct usable code for the "serving static file example" from the webob documentation.

This closes #33.
