### PR TITLE
Fix test failure on webob.static on Pypy

### DIFF
--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -79,16 +79,12 @@ class TestFileApp(unittest.TestCase):
             raise OSError()
 
         app = static.FileApp(self.tempfile)
-        old_open = __builtins__['open']
 
-        try:
-            __builtins__['open'] = open_ioerror
-            self.assertEqual(403, get_response(app).status_int)
+        app._open = open_ioerror
+        self.assertEqual(403, get_response(app).status_int)
 
-            __builtins__['open'] = open_oserror
-            self.assertEqual(403, get_response(app).status_int)
-        finally:
-            __builtins__['open'] = old_open
+        app._open = open_oserror
+        self.assertEqual(403, get_response(app).status_int)
 
 
 class TestFileIter(unittest.TestCase):

--- a/webob/static.py
+++ b/webob/static.py
@@ -27,6 +27,8 @@ class FileApp(object):
         kw.setdefault('content_encoding', content_encoding)
         kw.setdefault('accept_ranges', 'bytes')
         self.kw = kw
+        # Used for testing purpose
+        self._open = open
 
     @wsgify
     def __call__(self, req):
@@ -40,7 +42,7 @@ class FileApp(object):
             return exc.HTTPNotFound(comment=msg)
 
         try:
-            file = open(self.filename, 'rb')
+            file = self._open(self.filename, 'rb')
         except (IOError, OSError) as e:
             msg = "You are not permitted to view this file (%s)" % e
             return exc.HTTPForbidden(msg)


### PR DESCRIPTION
This should fix the error from
http://lists.repoze.org/pipermail/pyramid-checkins/2012-April/003847.html
