### PR TITLE
Range header fields can have LWS

### DIFF
--- a/tests/test_byterange.py
+++ b/tests/test_byterange.py
@@ -14,6 +14,8 @@ def test_not_satisfiable():
 
 def test_range_parse():
     assert isinstance(Range.parse('bytes=0-99'), Range)
+    assert isinstance(Range.parse('bytes = 0-99'), Range)
+    assert isinstance(Range.parse('bytes=0 - 102'), Range)
     assert Range.parse('bytes=10-5') is None
     assert Range.parse('bytes 5-10') is None
     assert Range.parse('words=10-5') is None

--- a/webob/byterange.py
+++ b/webob/byterange.py
@@ -2,7 +2,7 @@ import re
 
 __all__ = ['Range', 'ContentRange']
 
-_rx_range = re.compile('bytes=(\d*)-(\d*)')
+_rx_range = re.compile('bytes *= *(\d*) *- *(\d*)')
 _rx_content_range = re.compile(r'bytes (?:(\d+)-(\d+)|[*])/(?:(\d+)|[*])')
 
 class Range(object):


### PR DESCRIPTION
Hello,

While I've been doing swift can support both webob1.2/1.1, I found that webob 1.2 complain about LWS(linear white space) for Range header which is works well with webob 1.1.
(http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
(https://bugs.launchpad.net/swift/+bug/888371)

So, I made a patch for that.
