### PR TITLE
Fix case-sensitive behaviour in MIMEAccept and AcceptCharset.

### DIFF
--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -22,6 +22,15 @@ def test_init_accept_accept_charset():
                               ('unicode-1-1', 0.80000000000000004),
                               ('iso-8859-1', 1)]
 
+def test_init_accept_accept_charset_mixedcase():
+    """3.4 Character Sets
+           [...]
+           HTTP character sets are identified by case-insensitive tokens."""
+    accept = AcceptCharset('ISO-8859-5, UNICODE-1-1;q=0.8')
+    assert accept._parsed == [('iso-8859-5', 1),
+                              ('unicode-1-1', 0.80000000000000004),
+                              ('iso-8859-1', 1)]
+
 def test_init_accept_accept_charset_with_iso_8859_1():
     accept = Accept('iso-8859-1')
     assert accept._parsed == [('iso-8859-1', 1)]
@@ -263,6 +272,26 @@ def test_match():
 def test_accept_json():
     mimeaccept = MIMEAccept('text/html, *; q=.2, */*; q=.2')
     assert mimeaccept.best_match(['application/json']) == 'application/json'
+
+def test_accept_mixedcase():
+    """3.7 Media Types
+           [...]
+           The type, subtype, and parameter attribute names are case-
+           insensitive."""
+    mimeaccept = MIMEAccept('text/HtMl')
+    assert mimeaccept.accept_html()
+
+def test_match_mixedcase():
+    mimeaccept = MIMEAccept('image/jpg; q=.2, Image/pNg; Q=.4, image/*; q=.05')
+    assert mimeaccept.best_match(['Image/JpG']) == 'Image/JpG'
+    assert mimeaccept.best_match(['image/Tiff']) == 'image/Tiff'
+    assert mimeaccept.best_match(['image/Tiff', 'image/PnG', 'image/jpg']) == 'image/PnG'
+
+def test_match_uppercase_q():
+    """The relative-quality-factor "q" parameter is defined as an exact string
+       in "14.1 Accept" BNF grammar"""
+    mimeaccept = MIMEAccept('image/jpg; q=.4, Image/pNg; Q=.2, image/*; q=.05')
+    assert mimeaccept._parsed == [('image/jpg', 0.4), ('image/png', 1), ('image/*', 0.05)]
 
 # property tests
 

--- a/webob/acceptparse.py
+++ b/webob/acceptparse.py
@@ -246,9 +246,10 @@ class AcceptCharset(Accept):
     def parse(value):
         latin1_found = False
         for m, q in Accept.parse(value):
-            if m == '*' or m == 'iso-8859-1':
+            _m = m.lower()
+            if _m == '*' or _m == 'iso-8859-1':
                 latin1_found = True
-            yield m, q
+            yield _m, q
         if not latin1_found:
             yield ('iso-8859-1', 1)
 
@@ -273,12 +274,12 @@ class MIMEAccept(Accept):
     def parse(value):
         for mask, q in Accept.parse(value):
             try:
-                mask_major, mask_minor = mask.split('/')
+                mask_major, mask_minor = map(lambda x: x.lower(), mask.split('/'))
             except ValueError:
                 continue
             if mask_major == '*' and mask_minor != '*':
                 continue
-            yield (mask, q)
+            yield ("%s/%s" % (mask_major, mask_minor), q)
 
     def accept_html(self):
         """
@@ -297,13 +298,13 @@ class MIMEAccept(Accept):
         """
         _check_offer(offer)
         if '*' not in mask:
-            return offer == mask
+            return offer.lower() == mask.lower()
         elif mask == '*/*':
             return True
         else:
             assert mask.endswith('/*')
-            mask_major = mask[:-2]
-            offer_major = offer.split('/', 1)[0]
+            mask_major = mask[:-2].lower()
+            offer_major = offer.split('/', 1)[0].lower()
             return offer_major == mask_major
 
 


### PR DESCRIPTION
I'm enclosing an adapted version of the test script posted by Graham Klyne at
https://groups.google.com/forum/?fromgroups#!topic/pylons-discuss/XkDlQTj9m44

The behavior  Klyne observed contradicts the case-insensitivity required in rfc 2616.

if the following webob_accept_tests.py is being run with unpatched webob,
a mixed-case accept header will not match a lower-case offer:

$ wget --header='Accept: text/HtmL' 127.0.0.1:6543/
--2012-06-07 14:53:52--  http://127.0.0.1:6543/
Connecting to 127.0.0.1:6543... connected.
HTTP request sent, awaiting response... 404 Not Found
2012-06-07 14:53:52 ERROR 404: Not Found.

After installing a patched WebOb, the very same request will be
fulfilled:

$ wget --header='Accept: text/HtmL' 127.0.0.1:6543/
--2012-06-07 15:00:57--  http://127.0.0.1:6543/
Connecting to 127.0.0.1:6543... connected.
HTTP request sent, awaiting response... 200 OK
Length: 92 [text/html]
Saving to: `index.html'

100%[==================================>] 92          --.-K/s   in 0s      

2012-06-07 15:00:57 (6.99 MB/s) - `index.html' saved [92/92]

webob_accept_tests.py:

``` python
#!python
# encoding: utf-8

from pyramid.config import Configurator
from wsgiref.simple_server import make_server
from pyramid.view import view_config
from pyramid.response import Response

import sys

@view_config(route_name='service', request_method='GET',
             accept='application/xml')
def service_xml(request):
    return Response('<?xml version="1.0"?><root><element route_name="service"/></root>\n',
                    content_type='application/xml')

@view_config(route_name='service', request_method='GET',
             accept='text/turtle')
def service_turtle(request):
    return Response('Turtle, route_name=service\n', content_type='text/turtle')

@view_config(route_name='service', request_method='GET',
             accept="text/HTML")
def service_html(request):
    return Response('<html><head><title>html service</title></head><body><p>route_name=service</p></body></html>\n')

@view_config(route_name='service', request_method='GET',
             accept='text/plain')
def service_plaintext(request):
    return Response('Plain text, route_name=service\n', content_type='text/plain')

if __name__ == '__main__':
    # configuration settings
    if len(sys.argv) > 1:
        httpport = int(sys.argv[1])
    else:
        httpport = 6543
    settings = {}
    settings['reload_all'] = True
    settings['debug_all'] = True
    # configuration setup
    config = Configurator(settings=settings)
    config.add_route(name='service', pattern='/')
    config.scan()
    # serve app
    app = config.make_wsgi_app()
    server = make_server('', httpport, app)
    print 'Listening on port %i' % httpport
    server.serve_forever()
```
