### PR TITLE
Adds support for draft HTTP error code '451: Unavailable For Legal Reaso...

### DIFF
--- a/webob/exc.py
+++ b/webob/exc.py
@@ -960,6 +960,25 @@ class HTTPRequestHeaderFieldsTooLarge(HTTPClientError):
     explanation = (
         'The request header fields were too large')
 
+class HTTPUnavailableForLegalReasons(HTTPClientError):
+    """
+    subclass of :class:`~HTTPClientError`
+
+    This indicates that the server is unable to process the request
+    because of legal reasons, e.g. censorship or government-mandated
+    blocked access.
+
+    From the draft "A New HTTP Status Code for Legally-restricted Resources"
+    by Tim Bray:
+
+    http://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-00
+
+    code: 451, title: Unavailable For Legal Reasons
+    """
+    code = 451
+    title = 'Unavailable For Legal Reasons'
+    explanation = ('The resource is not available due to legal reasons.')
+
 ############################################################
 ## 5xx Server Error
 ############################################################


### PR DESCRIPTION
I'm possibly jumping the gun a bit since the draft of this status is brand new, but I wanted to get this out there while I was thinking about it (also, RIP Ray Bradbury).

It's probably reasonable to hold off on merging this request until such time as the draft is accepted or until it gains a little traction, at which point the docstring could probably use an update as drafts aren't supposed to be cited for reference.

The draft can be perused at:  http://datatracker.ietf.org/doc/draft-tbray-http-legally-restricted-status/  -- this seems to be a decent place to watch it for updates.
