### PR TITLE
Fix bug due to uWSGI's incorrect handling of SCRIPT_NAME

### DIFF
--- a/webob/request.py
+++ b/webob/request.py
@@ -141,7 +141,8 @@ class BaseRequest(object):
 
         #uWSGI incorrectly handles script name. ('/' when is should
         #be ''.)  This fixes that.
-        if environ.get('SCRIPT_NAME', '')=='/':
+        if ('uwsgi.version' in environ and
+                environ.get('SCRIPT_NAME', '')=='/'):
             environ['SCRIPT_NAME'] = ''
 
         d = self.__dict__


### PR DESCRIPTION
uWSGI passes "/" as the script name when it should be "".  This causes problems with frameworks such as Pyramid:  All my URLs had double slashes, eg: "//example/test".

The underlying problem is with uWSGI, so I understand you may not want to incorporate this code into the project, but I thought I'd offer.
