### PR TITLE
Make the "bytes=" unit case-insensitive in Range header

### DIFF
--- a/tests/test_byterange.py
+++ b/tests/test_byterange.py
@@ -14,6 +14,7 @@ def test_not_satisfiable():
 
 def test_range_parse():
     assert isinstance(Range.parse('bytes=0-99'), Range)
+    assert isinstance(Range.parse('BYTES=0-99'), Range)
     assert isinstance(Range.parse('bytes = 0-99'), Range)
     assert isinstance(Range.parse('bytes=0 - 102'), Range)
     assert Range.parse('bytes=10-5') is None

--- a/webob/byterange.py
+++ b/webob/byterange.py
@@ -2,7 +2,7 @@ import re
 
 __all__ = ['Range', 'ContentRange']
 
-_rx_range = re.compile('bytes *= *(\d*) *- *(\d*)')
+_rx_range = re.compile('bytes *= *(\d*) *- *(\d*)', flags=re.I)
 _rx_content_range = re.compile(r'bytes (?:(\d+)-(\d+)|[*])/(?:(\d+)|[*])')
 
 class Range(object):


### PR DESCRIPTION
I was unable to find any clear guidance in RFC-2616 or elsewhere.
It looks like they simply forgot to mention if token called
"bytes-unit" is case-sensitive or not. Generally fields are
not sensitive, but there are exceptions. Certainly, it is valid
to accept extra units, if we deem "bytes=" and "BYTES=" different.

This patch came about because OpenStack Swift throws an exception
on WebOb 1.2. It worked in WebOb 1.0.8, where we had a code that
invoked .lower() before matching.
