### PR TITLE
Permit and understand RFC 6585 HTTP status codes

### DIFF
--- a/webob/util.py
+++ b/webob/util.py
@@ -110,6 +110,9 @@ status_reasons = {
     423: 'Locked',
     424: 'Failed Dependency',
     426: 'Upgrade Required',
+    428: 'Precondition Required',
+    429: 'Too Many Requests',
+    431: 'Request Header Fields Too Large',
 
     # Server Error
     500: 'Internal Server Error',
@@ -120,6 +123,7 @@ status_reasons = {
     505: 'HTTP Version Not Supported',
     507: 'Insufficient Storage',
     510: 'Not Extended',
+    511: 'Network Authentication Required',
 }
 
 # generic class responses as per RFC2616


### PR DESCRIPTION
This patch makes WebOb accept the excellent and useful status codes defined in RFC 6585, which is APPROVED per https://datatracker.ietf.org/doc/rfc6585/history/ .

Thanks for your consideration.
