### PR TITLE
Ignore invalid mime wildcards in MIMEAccept

### DIFF
--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -252,6 +252,8 @@ def test_mime_init():
     assert mimeaccept._parsed == [('*/*', 1)]
     mimeaccept = MIMEAccept('*/png')
     assert mimeaccept._parsed == []
+    mimeaccept = MIMEAccept('image/pn*')
+    assert mimeaccept._parsed == []
     mimeaccept = MIMEAccept('image/*')
     assert mimeaccept._parsed == [('image/*', 1)]
 

--- a/webob/acceptparse.py
+++ b/webob/acceptparse.py
@@ -279,6 +279,10 @@ class MIMEAccept(Accept):
                 continue
             if mask_major == '*' and mask_minor != '*':
                 continue
+            if mask_major != "*" and "*" in mask_major:
+                continue
+            if mask_minor != "*" and "*" in mask_minor:
+                continue
             yield ("%s/%s" % (mask_major, mask_minor), q)
 
     def accept_html(self):


### PR DESCRIPTION
The current implementation of MIMEAccept will happily parse malformed wildcard strings like "image/pn*" at parse time, but then trigger an AssertionError during matching:

```
>>> m = MIMEAccept("image/pn*")
>>> m.best_match(["image/png"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "webob/acceptparse.py", line 176, in best_match
    if self._match(mask, offer):
  File "webob/acceptparse.py", line 305, in _match
    assert mask.endswith('/*')
AssertionError
>>>
```

This patch changes MIMEAccept.parse to filter out these invalid values so that client-provided data cannot trigger an assertion.
