### PR TITLE
Added a fix and modified the unit tests to accomodate.

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -941,7 +941,6 @@ def test_encode_content_gzip_notyet_gzipped():
     eq_(res.content_length, 23)
     eq_(res.app_iter, [
         b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xff',
-        b'',
         b'K\xcb\xcf\x07\x00',
         b'!es\x8c\x03\x00\x00\x00'
         ])
@@ -954,7 +953,6 @@ def test_encode_content_gzip_notyet_gzipped_lazy():
     eq_(res.content_length, None)
     eq_(list(res.app_iter), [
         b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xff',
-        b'',
         b'K\xcb\xcf\x07\x00',
         b'!es\x8c\x03\x00\x00\x00'
         ])


### PR DESCRIPTION
The bug report can be found here:

https://github.com/Pylons/webob/issues/84

SSL v3 (wrap_socket) blows up if the WSGI iterator yields an empty byte string. The compress function will buffer input if there isn't enough and return an empty byte string. As a result, the wrap_socket function of the ssl module will raise the following exception:

```
ssl.SSLError: EOF occurred in violation of protocol as a result of zlib compression.
```
