### PR TITLE
Use list comprehension for multidict getall

### DIFF
--- a/webob/multidict.py
+++ b/webob/multidict.py
@@ -115,11 +115,7 @@ class MultiDict(MutableMapping):
         """
         Return a list of all values matching the key (may be an empty list)
         """
-        result = []
-        for k, v in self._items:
-            if key == k:
-                result.append(v)
-        return result
+        return [v for k, v in self._items if k == key]
 
     def getone(self, key):
         """


### PR DESCRIPTION
Removes list appends to the getall() method and uses list comprehension.
