### PR TITLE
putting post ordering back in the hands of the client

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -827,7 +827,12 @@ class TestRequestCommon(unittest.TestCase):
                           '/', content_type='application/json', POST={})
 
     def test_blank__post_urlencoded(self):
-        request = self._blankOne('/', POST={'first':1, 'second':2})
+        from webob.multidict import MultiDict
+        POST = MultiDict()
+        POST["first"] = 1
+        POST["second"] = 2
+
+        request = self._blankOne('/', POST=POST)
         self.assertEqual(request.method, 'POST')
         self.assertEqual(request.content_type,
                          'application/x-www-form-urlencoded')
@@ -835,9 +840,15 @@ class TestRequestCommon(unittest.TestCase):
         self.assertEqual(request.content_length, 16)
 
     def test_blank__post_multipart(self):
-        request = self._blankOne(
-            '/', POST={'first':'1', 'second':'2'},
-            content_type='multipart/form-data; boundary=boundary')
+        from webob.multidict import MultiDict
+        POST = MultiDict()
+        POST["first"] = "1"
+        POST["second"] = "2"
+
+
+        request = self._blankOne('/', 
+                                 POST=POST,
+                                 content_type='multipart/form-data; boundary=boundary')
         self.assertEqual(request.method, 'POST')
         self.assertEqual(request.content_type, 'multipart/form-data')
         expected = (
@@ -854,9 +865,11 @@ class TestRequestCommon(unittest.TestCase):
     def test_blank__post_files(self):
         import cgi
         from webob.request import _get_multipart_boundary
-        POST = {'first':('filename1', BytesIO(b'1')),
-                       'second':('filename2', '2'),
-                       'third': '3'}
+        from webob.multidict import MultiDict
+        POST = MultiDict()
+        POST["first"] = ('filename1', BytesIO(b'1'))
+        POST["second"] = ('filename2', '2')
+        POST["third"] = "3"
         request = self._blankOne('/', POST=POST)
         self.assertEqual(request.method, 'POST')
         self.assertEqual(request.content_type, 'multipart/form-data')

--- a/webob/request.py
+++ b/webob/request.py
@@ -1454,9 +1454,8 @@ def environ_add_POST(env, data, content_type=None):
     if env['REQUEST_METHOD'] not in ('POST', 'PUT'):
         env['REQUEST_METHOD'] = 'POST'
     has_files = False
-    if hasattr(data, 'items'):
-        data = sorted(data.items())
-        for k, v in data:
+    if hasattr(data, 'iteritems'):
+        for k, v in data.iteritems():
             if isinstance(v, (tuple, list)):
                 has_files = True
                 break
@@ -1467,7 +1466,7 @@ def environ_add_POST(env, data, content_type=None):
             content_type = 'application/x-www-form-urlencoded'
     if content_type.startswith('multipart/form-data'):
         if not isinstance(data, bytes):
-            content_type, data = _encode_multipart(data, content_type)
+            content_type, data = _encode_multipart(data.iteritems(), content_type)
     elif content_type.startswith('application/x-www-form-urlencoded'):
         if has_files:
             raise ValueError('Submiting files is not allowed for'


### PR DESCRIPTION
in the rare case when order matters for clients you need to use a MultiDict and insert in the intended order
