### PR TITLE
delete response.content_type if assigning 204 (No Content) to response.status

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -75,6 +75,16 @@ def test_set_response_status_str_generic_reason():
     assert res.status_code == 299
     assert res.status == '299 Success'
 
+def test_set_response_status_204():
+    # setting the response status to 204 should remove the content_type
+    req = BaseRequest.blank('/')
+    res = req.get_response(simple_app)
+    res.status = 204
+    assert res.status_code == 204
+    assert res.status == '204 No Content'
+    assert res.content_type is None
+    assert res.content_length is None
+
 def test_set_response_status_code():
     req = BaseRequest.blank('/')
     res = req.get_response(simple_app)

--- a/webob/response.py
+++ b/webob/response.py
@@ -276,6 +276,11 @@ class Response(object):
             self._status = '%d %s' % (code, status_reasons[code])
         except KeyError:
             self._status = '%d %s' % (code, status_generic_reasons[code // 100])
+        # responses with status == 204 must not include a message body,
+        # so probably should not have a Content-Type header as well
+        if code in [204, 205, 304]:
+            del self.content_type
+            del self.content_length
 
     status_code = status_int = property(_status_code__get, _status_code__set,
                            doc=_status_code__get.__doc__)

--- a/webob/response.py
+++ b/webob/response.py
@@ -277,7 +277,8 @@ class Response(object):
         except KeyError:
             self._status = '%d %s' % (code, status_generic_reasons[code // 100])
         # responses with status == 204 must not include a message body,
-        # so probably should not have a Content-Type header as well
+        # so probably should not have a Content-Type header as well.
+        # this mimics the "empty_body = True" behavior from webob.exc
         if code in [204, 205, 304]:
             del self.content_type
             del self.content_length


### PR DESCRIPTION
When assigning the 204 status code to a response object, the `content_type` attribute is still present due to `default_content_type = 'text/html'`.

We encountered problems with this behavior in some response handling code which does not explicitly create a `HTTPNoContent` response object having `empty_body = True` but reuses an existing regular response object.

For example, http unit tests using `WebTest` croak with:
> AssertionError: Content-Type header found in a 204 response, which must not return content.
> -- webtest/lint.py, line 447, in check_content_type
