### PR TITLE
Support Response.body_file.tell() method for ZipFile friendly

### DIFF
--- a/docs/differences.txt
+++ b/docs/differences.txt
@@ -61,6 +61,9 @@ Response
 ``flush()`` and ``tell()``:
     Not available.
 
+``tell()``:
+    Available in ``res.body_file.tell()``.
+
 There are also many extra methods and attributes on WebOb Response
 objects.
 
@@ -162,7 +165,7 @@ dictionary-like:
 ``has_header(header)``:
     Use ``header in res.headers``
 
-``flush()``, ``tell()``:
+``flush()``:
     Not available
 
 ``content``:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -465,6 +465,16 @@ def test_response_file_body_writelines():
     rbo.flush() # noop
     eq_(res.app_iter, [b'foo', b'bar', b'baz'])
 
+def test_response_file_body_tell():
+    import zipfile
+    from webob.response import ResponseBodyFile
+    rbo = ResponseBodyFile(Response())
+    eq_(rbo.tell(), 0)
+    writer = zipfile.ZipFile(rbo, 'w')
+    writer.writestr('zinfo_or_arcname', b'foo')
+    writer.close()
+    eq_(rbo.tell(), 133)
+
 def test_response_write_non_str():
     res = Response()
     assert_raises(TypeError, res.write, object())

--- a/webob/response.py
+++ b/webob/response.py
@@ -1151,6 +1151,11 @@ class ResponseBodyFile(object):
     def flush(self):
         pass
 
+    def tell(self):
+        if self.response._app_iter is None:
+            return 0
+        return sum([len(str(chunk)) for chunk in self.response._app_iter])
+
 
 
 class AppIterRange(object):


### PR DESCRIPTION
For example, such as generate the Apple's Passbook.

```python
>>> writer = zipfile.ZipFile(ResponseBodyFile(Response()), 'w')
>>> writer.writestr('zinfo_or_arcname', b'foo')
>>> writer.close()
```

Thanks.