### PR TITLE
Build and release wheels for Webob

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [aliases]
-distribute = register sdist upload
+distribute = register sdist bdist_wheel upload
 dev = develop easy_install webob[testing]
 docs = develop easy_install webob[docs]
 
@@ -8,3 +8,6 @@ detailed-errors = True
 cover-erase=True
 cover-package=webob
 nocapture=True
+
+[wheel]
+universal = 1


### PR DESCRIPTION
I added some configuration to setup.cfg so it can build and release universal wheels (compatible both python2 & 3).

Wheels are an awesome new [binary distribution format](http://pythonwheels.com/) for python that are pip installable, don't need to build on the user side, and work with virtualenv, among other advantages.

Hopefully you might consider releasing one for Webob to pypi :)

Note, you'll need the `wheel` package installed to run the `python setup.py bdist_wheel` command. 

More info links:
https://pypi.python.org/pypi/wheel
http://wheel.readthedocs.org/en/latest/
http://www.python.org/dev/peps/pep-0427/
