### PR TITLE
Avoid escaping environ keys that are not used by WSGIHTTPException body_template

### DIFF
--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -307,6 +307,40 @@ def test_HTTPMove_call_query_string():
     environ['PATH_INFO'] = '/'
     assert_equal( m( environ, start_response ), [] )
 
+def test_HTTPFound_unused_environ_variable():
+    class Crashy(object):
+        def __str__(self):
+            raise Exception('I crashed!')
+
+    def start_response(status, headers, exc_info=None):
+        pass
+    environ = {
+       'wsgi.url_scheme': 'HTTP',
+       'SERVER_NAME': 'localhost',
+       'SERVER_PORT': '80',
+       'REQUEST_METHOD': 'GET',
+       'PATH_INFO': '/',
+       'HTTP_ACCEPT': 'text/html',
+       'crashy': Crashy()
+    }
+
+    m = _HTTPMove(location='http://www.example.com')
+    assert_equal( m( environ, start_response ), [
+        b'<html>\n'
+        b' <head>\n'
+        b'  <title>None None</title>\n'
+        b' </head>\n'
+        b' <body>\n'
+        b'  <h1>None None</h1>\n'
+        b'  The resource has been moved to '
+        b'<a href="http://www.example.com">'
+        b'http://www.example.com</a>;\n'
+        b'you should be redirected automatically.\n' 
+        b'\n\n'
+        b' </body>\n'
+        b'</html>' ] 
+    )
+
 def test_HTTPExceptionMiddleware_ok():
     def app( environ, start_response ):
         return '123'

--- a/webob/exc.py
+++ b/webob/exc.py
@@ -184,6 +184,12 @@ tag_re = re.compile(r'<.*?>', re.S)
 br_re = re.compile(r'<br.*?>', re.I|re.S)
 comment_re = re.compile(r'<!--|-->')
 
+def lazify(func):
+    class _lazyfied(object):
+        def __init__(self, s): self._s = s
+        def __str__(self): return func(self._s)
+    return _lazyfied
+
 def no_escape(value):
     if value is None:
         return ''
@@ -277,6 +283,7 @@ ${body}''')
         return self.detail or self.explanation
 
     def _make_body(self, environ, escape):
+        escape = lazify(escape)
         args = {
             'explanation': escape(self.explanation),
             'detail': escape(self.detail or ''),


### PR DESCRIPTION
Currently WSGIHTTPException, when served as responses, call _make_body to prepare their body.
_make_body gets each entry of the environ and escapes it at https://github.com/Pylons/webob/blob/master/webob/exc.py#L292 if the user stored any property into a previously used request it will end up being in the environ and so will be escaped.

The side effect is that if the user stored any property which the conversion to string fails, the Response will crash even though that property is not used at all.
This is especially true in case you stored your user inside the request (like repoze.who does), the user is an SQLAlchemy model and you rollback the transaction before performing a redirect.

As redirections are subclasses of _HTTPMove (which provides a custom template) the _make_body will iterate on the repoze.who identity, which contains the User and will convert it to string (through html_escape). As transaction has previously been rolled back the user is now detached from the session and so cannot be converted if it provided a custom __str__/__repr__ method that gets any of its properties.

The proposed patch solves the issue by lazily escaping environ values, so that only those that are used by the body_template are actually evaluated.