### PR TITLE
Use '\r\n' line endings in Response.__str__.

### DIFF
--- a/docs/news.txt
+++ b/docs/news.txt
@@ -7,6 +7,8 @@ unreleased
 Bug Fixes
 ~~~~~~~~~
 
+- Use '\r\n' line endings in ``Response.__str__``.
+
 - Fix a bug in ``SignedSerializer`` preventing secrets from containing
   higher-order characters. See https://github.com/Pylons/webob/issues/136
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -372,6 +372,10 @@ def test_content_type_in_headerlist():
     finally:
         Response.default_content_type = default_content_type
 
+def test_str_crlf():
+    res = Response('test')
+    assert '\r\n' in str(res)
+
 def test_from_file():
     res = Response('test')
     inp = io.BytesIO(bytes_(str(res)))

--- a/webob/response.py
+++ b/webob/response.py
@@ -231,7 +231,7 @@ class Response(object):
         parts += map('%s: %s'.__mod__, self.headerlist)
         if not skip_body and self.body:
             parts += ['', self.text if PY3 else self.body]
-        return '\n'.join(parts)
+        return '\r\n'.join(parts)
 
     #
     # status, status_code/status_int


### PR DESCRIPTION
Response headers should have CRLF line endings the same as Request headers. http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2 