### PR TITLE
Native `str` strings from Response.from_file

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -409,6 +409,12 @@ def test_file_bad_header():
     file_w_bh = io.BytesIO(b'200 OK\nBad Header')
     assert_raises(ValueError, Response.from_file, file_w_bh)
 
+def test_from_file_not_unicode_headers():
+    inp = io.BytesIO(
+        b'200 OK\n\tContent-Type: text/html; charset=UTF-8')
+    res = Response.from_file(inp)
+    eq_(res.headerlist[0][0].__class__, str)
+
 def test_set_status():
     res = Response()
     res.status = "200"

--- a/webob/response.py
+++ b/webob/response.py
@@ -184,10 +184,10 @@ class Response(object):
             except ValueError:
                 raise ValueError('Bad header line: %r' % line)
             value = value.strip()
-            if not is_text:
-                header_name = header_name.decode('utf-8')
-                value = value.decode('utf-8')
-            headerlist.append((header_name, value))
+            headerlist.append((
+                native_(header_name, 'latin-1'),
+                native_(value, 'latin-1')
+            ))
         r = cls(
             status=status,
             headerlist=headerlist,


### PR DESCRIPTION
Make sure that header names extracted with Response.from_file are `str` instances otherwise most WSGI implementations will reject the response.

Should fix issue https://github.com/Pylons/webob/issues/99