### PR TITLE
Handle the X-FORWARDED-PROTO header from the SSL off-load

### DIFF
--- a/webob/request.py
+++ b/webob/request.py
@@ -140,6 +140,11 @@ class BaseRequest(object):
             )
         d = self.__dict__
         d['environ'] = environ
+        
+        # Handle the X-FORWARDED-PROTO header form the SSL off-load
+        if 'HTTP_X_FORWARDED_PROTO' in environ:
+            d['environ']['wsgi.url_scheme'] = environ['HTTP_X_FORWARDED_PROTO']
+
         if kw:
             cls = self.__class__
             if 'method' in kw:


### PR DESCRIPTION
In order to have my pyramid app working correctly, I had to patch webob as is using mod_wsgi.

I know this is not enough because in case you are not behind a proxy, anyone could change this header.
Also I want to open the discussion about the best way to take care of this using mod_wsgi.
