### PR TITLE
Make request.host prefer HTTP_X_FORWARDED_HOST if present

### DIFF
--- a/webob/request.py
+++ b/webob/request.py
@@ -656,8 +656,13 @@ class BaseRequest(object):
         return self.environ.get('HTTP_X_REQUESTED_WITH', '') == 'XMLHttpRequest'
 
     def _host__get(self):
-        """Host name provided in HTTP_HOST, with fall-back to SERVER_NAME"""
-        if 'HTTP_HOST' in self.environ:
+        """
+        Host name provided in HTTP_X_FORWARDED_HOST or HTTP_HOST, with
+        fall-back to SERVER_NAME
+        """
+        if 'HTTP_X_FORWARDED_HOST' in self.environ:
+            return self.environ['HTTP_X_FORWARDED_HOST']
+        elif 'HTTP_HOST' in self.environ:
             return self.environ['HTTP_HOST']
         else:
             return '%(SERVER_NAME)s:%(SERVER_PORT)s' % self.environ


### PR DESCRIPTION
The `X-Forwarded-Host` HTTP request header is often set by proxies. It is useful because it tells the app the host that the client requested from the proxy server, which might be different from the `"Host:"` header that was received by the origin server, like if the proxy proxies to a virtual host on the origin server.
