### PR TITLE
bring docs up-to-date with actual wsgify signature

### DIFF
--- a/webob/dec.py
+++ b/webob/dec.py
@@ -222,7 +222,7 @@ class wsgify(object):
         Use this like::
 
             @wsgify.middleware
-            def restrict_ip(app, req, ips):
+            def restrict_ip(req, app, ips):
                 if req.remote_addr not in ips:
                     raise webob.exc.HTTPForbidden('Bad IP: %s' % req.remote_addr)
                 return app
@@ -236,7 +236,7 @@ class wsgify(object):
         Or if you want to write output-rewriting middleware::
 
             @wsgify.middleware
-            def all_caps(app, req):
+            def all_caps(req, app):
                 resp = req.get_response(app)
                 resp.body = resp.body.upper()
                 return resp


### PR DESCRIPTION
the tests and code clearly expect (req, app, **kw) and it makes sense that it
would be that way since req is the ephemeral argument and the rest are
defined at setup-time. The documented order before was (app, req, **kw)
which puts the req in-between multiple config arguments in the
signature.

fixes #25, #120