### PR TITLE
Fix documentation/cookie handling in response.set_cookie()

### DIFF
--- a/docs/news.txt
+++ b/docs/news.txt
@@ -4,6 +4,18 @@ News
 Unreleased
 ----------
 
+Backwards Incompatibilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``Morsel`` will no longer accept a cookie value that does not meet RFC6265's
+  cookie-octet specification. Upon calling ``Morsel.serialize`` a warning will
+  be issued, in the future this will raise a ``ValueError``, please update your
+  cookie handling code. See https://github.com/Pylons/webob/pull/172
+
+- ``response.set_cookie`` now uses the internal ``make_cookie`` API, which will
+  issue warnings if cookies are set with invalid bytes. See
+  https://github.com/Pylons/webob/pull/172
+
 Documentation Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -19,13 +31,6 @@ Bug/Documentation Fixes
   https://github.com/Pylons/webob/issues/166 and
   https://github.com/Pylons/webob/issues/171
 
-Backwards Incompatibilities
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- ``response.set_cookie`` will no longer accept unicode values because
-  ``cookies.make_cookie`` does not accept unicode values. Accepting unicode
-  values was technically contra-spec, and might not have been accepted by all
-  browsers.
 
 1.4 (2014-05-14)
 ----------------

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -12,6 +12,20 @@ Backwards Incompatibilities
   be issued, in the future this will raise a ``ValueError``, please update your
   cookie handling code. See https://github.com/Pylons/webob/pull/172
 
+  The cookie-octet specification in RFC6265 states the following characters are
+  valid in a cookie value:
+  
+  Hex Range     Actual Characters
+  ---------     -----------------
+  [0x21     ]   !
+  [0x25-0x2B]   #$%&'()*+ 
+  [0x2D-0x3A]   -./0123456789: 
+  [0x3C-0x5B]   <=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[
+  [0x5D-0x7E]   ]^_`abcdefghijklmnopqrstuvwxyz{|}~
+
+  RFC6265 suggests using base 64 to serialize data before storing data in a
+  cookie.
+
 - ``response.set_cookie`` now uses the internal ``make_cookie`` API, which will
   issue warnings if cookies are set with invalid bytes. See
   https://github.com/Pylons/webob/pull/172

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -10,6 +10,23 @@ Documentation Changes
 - Remove the WebDAV only from certain HTTP Exceptions, these exceptions may
   also be used by REST services for example.
 
+Bug/Documentation Fixes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``response.set_cookie`` now has proper documentation for ``max_age`` and
+  ``expires``. The code has also been refactored to use ``cookies.make_cookie``
+  instead of duplicating the code. This fixes
+  https://github.com/Pylons/webob/issues/166 and
+  https://github.com/Pylons/webob/issues/171
+
+Backwards Incompatibilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``response.set_cookie`` will no longer accept unicode values because
+  ``cookies.make_cookie`` does not accept unicode values. Accepting unicode
+  values was technically contra-spec, and might not have been accepted by all
+  browsers.
+
 1.4 (2014-05-14)
 ----------------
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -7,6 +7,8 @@ import unittest
 from webob.compat import native_
 from webob.compat import PY3
 
+cookies._should_raise = True
+
 def test_cookie_empty():
     c = cookies.Cookie() # empty cookie
     eq_(repr(c), '<Cookie: []>')
@@ -445,6 +447,14 @@ class CookieProfileTest(CommonCookieProfile):
         ret = cookie.get_value()
 
         self.assertEqual(ret, "test")
+
+    def test_with_invalid_cookies(self):
+        request = self.makeOneRequest()
+        request.cookies['uns'] = 'InRlc3Q'
+        cookie = self.makeOne(request=request)
+        ret = cookie.get_value()
+
+        self.assertEqual(ret, None)
 
 class SignedCookieProfileTest(CommonCookieProfile):
     def makeOne(self, secret='seekrit', salt='salty', name='uns', **kw):

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -42,9 +42,9 @@ def test_cookie_complex():
 
 def test_cookie_complex_serialize():
     c = cookies.Cookie('dismiss-top=6; CP=null*, '\
-                       'PHPSESSID=0a539d42abc001cdc762809248d4beed, a="42,"')
+                       'PHPSESSID=0a539d42abc001cdc762809248d4beed, a="42"')
     eq_(c.serialize(),
-        'CP=null*; PHPSESSID=0a539d42abc001cdc762809248d4beed; a="42\\054"; '
+        'CP=null*; PHPSESSID=0a539d42abc001cdc762809248d4beed; a=42; '
         'dismiss-top=6')
 
 def test_cookie_load_multiple():

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -7,7 +7,11 @@ import unittest
 from webob.compat import native_
 from webob.compat import PY3
 
-cookies._should_raise = True
+def setup_module(module):
+    cookies._should_raise = True
+
+def teardown_module(module):
+    cookies._should_raise = False
 
 def test_cookie_empty():
     c = cookies.Cookie() # empty cookie

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -234,19 +234,19 @@ class TestRequestCookies(unittest.TestCase):
         self.assertRaises(ValueError, inst.__setitem__, 'a', value)
 
     def test__setitem__success_no_existing_headers(self):
-        value = native_(b'La Pe\xc3\xb1a', 'utf-8')
+        value = native_(b'test_cookie', 'utf-8')
         environ = {}
         inst = self._makeOne(environ)
         inst['a'] = value
-        self.assertEqual(environ['HTTP_COOKIE'], 'a="La Pe\\303\\261a"')
+        self.assertEqual(environ['HTTP_COOKIE'], 'a=test_cookie')
 
     def test__setitem__success_append(self):
-        value = native_(b'La Pe\xc3\xb1a', 'utf-8')
+        value = native_(b'test_cookie', 'utf-8')
         environ = {'HTTP_COOKIE':'a=1; b=2'}
         inst = self._makeOne(environ)
         inst['c'] = value
         self.assertEqual(
-            environ['HTTP_COOKIE'], 'a=1; b=2; c="La Pe\\303\\261a"')
+            environ['HTTP_COOKIE'], 'a=1; b=2; c=test_cookie')
 
     def test__setitem__success_replace(self):
         environ = {'HTTP_COOKIE':'a=1; b="La Pe\\303\\261a"; c=3'}

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -438,6 +438,14 @@ class CookieProfileTest(CommonCookieProfile):
         cookie = self.makeOne(serializer=RaisingSerializer())
         self.assertEqual(cookie.get_value(), None)
 
+    def test_with_cookies(self):
+        request = self.makeOneRequest()
+        request.cookies['uns'] = 'InRlc3Qi'
+        cookie = self.makeOne(request=request)
+        ret = cookie.get_value()
+
+        self.assertEqual(ret, "test")
+
 class SignedCookieProfileTest(CommonCookieProfile):
     def makeOne(self, secret='seekrit', salt='salty', name='uns', **kw):
         if 'request' in kw:

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -151,11 +151,6 @@ def test_serialize_max_age_str():
     result = cookies.serialize_max_age(val)
     eq_(result, b'86400')
 
-def test_escape_comma_semi_dquote():
-    c = cookies.Cookie()
-    c['x'] = b'";,"'
-    eq_(c.serialize(True), r'x="\042\073\054\042"')
-
 def test_parse_qmark_in_val():
     v = r'x="\"\073\054\""; expires=Sun, 12-Jun-2011 23:16:01 GMT'
     c = cookies.Cookie(v)

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 from webob import cookies
 from webob.compat import text_
-from nose.tools import eq_
+from nose.tools import (eq_, assert_raises)
 import unittest
 from webob.compat import native_
 from webob.compat import PY3

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -92,30 +92,37 @@ def test_ch_unquote():
     eq_(cookies._unquote(b'"hello world'), b'"hello world')
     eq_(cookies._unquote(b'hello world'), b'hello world')
     eq_(cookies._unquote(b'"hello world"'), b'hello world')
-    eq_(cookies._value_quote(b'hello world'), b'"hello world"')
+
+    # Spaces are not valid in cookies, we support getting them, but won't support sending them
+    assert_raises(ValueError, cookies._value_quote, b'hello world')
+
     # quotation mark escaped w/ backslash is unquoted correctly (support
     # pre webob 1.3 cookies)
     eq_(cookies._unquote(b'"\\""'), b'"')
     # we also are able to unquote the newer \\042 serialization of quotation
     # mark
     eq_(cookies._unquote(b'"\\042"'), b'"')
-    # but when we generate a new cookie, quote using normal octal quoting
-    # rules
-    eq_(cookies._value_quote(b'"'), b'"\\042"')
+
+    # New cookies can not contain quotes.
+    assert_raises(ValueError, cookies._value_quote, b'"')
+
     # backslash escaped w/ backslash is unquoted correctly (support
     # pre webob 1.3 cookies)
     eq_(cookies._unquote(b'"\\\\"'), b'\\')
     # we also are able to unquote the newer \\134 serialization of backslash
     eq_(cookies._unquote(b'"\\134"'), b'\\')
-    # but when we generate a new cookie, quote using normal octal quoting
-    # rules
-    eq_(cookies._value_quote(b'\\'), b'"\\134"')
+
+    # Cookies may not contain a backslash
+    assert_raises(ValueError, cookies._value_quote, b'\\')
+
     # misc byte escaped as octal
     eq_(cookies._unquote(b'"\\377"'), b'\xff')
-    eq_(cookies._value_quote(b'\xff'), b'"\\377"')
+
+    assert_raises(ValueError, cookies._value_quote, b'\xff')
+
     # combination
     eq_(cookies._unquote(b'"a\\"\\377"'), b'a"\xff')
-    eq_(cookies._value_quote(b'a"\xff'), b'"a\\042\\377"')
+    assert_raises(ValueError, cookies._value_quote, b'a"\xff')
 
 def test_cookie_invalid_name():
     c = cookies.Cookie()

--- a/tests/test_cookies_bw.py
+++ b/tests/test_cookies_bw.py
@@ -19,8 +19,8 @@ def test_invalid_cookie_space():
         
         cookies._value_quote(b'hello world')
 
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "ValueError" in str(w[-1].message)
+        eq_(len(w), 1)
+        eq_(issubclass(w[-1].category, DeprecationWarning), True)
+        eq_("ValueError" in str(w[-1].message), True)
 
     cookies._should_raise = True

--- a/tests/test_cookies_bw.py
+++ b/tests/test_cookies_bw.py
@@ -9,9 +9,13 @@ from webob.compat import PY3
 
 import warnings
 
-def test_invalid_cookie_space():
+def setup_module(module):
     cookies._should_raise = False
 
+def teardown_module(module):
+    cookies._should_raise = False
+
+def test_invalid_cookie_space():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
@@ -22,5 +26,3 @@ def test_invalid_cookie_space():
         eq_(len(w), 1)
         eq_(issubclass(w[-1].category, RuntimeWarning), True)
         eq_("ValueError" in str(w[-1].message), True)
-
-    cookies._should_raise = True

--- a/tests/test_cookies_bw.py
+++ b/tests/test_cookies_bw.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+from webob import cookies
+from webob.compat import text_
+from nose.tools import (eq_, assert_raises)
+import unittest
+from webob.compat import native_
+from webob.compat import PY3
+
+import warnings
+
+def test_invalid_cookie_space():
+    cookies._should_raise = False
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Trigger a warning.
+        
+        cookies._value_quote(b'hello world')
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "ValueError" in str(w[-1].message)
+
+    cookies._should_raise = True

--- a/tests/test_cookies_bw.py
+++ b/tests/test_cookies_bw.py
@@ -20,7 +20,7 @@ def test_invalid_cookie_space():
         cookies._value_quote(b'hello world')
 
         eq_(len(w), 1)
-        eq_(issubclass(w[-1].category, DeprecationWarning), True)
+        eq_(issubclass(w[-1].category, RuntimeWarning), True)
         eq_("ValueError" in str(w[-1].message), True)
 
     cookies._should_raise = True

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -683,6 +683,20 @@ def test_set_cookie_expires_is_not_None_and_max_age_is_None():
     eq_(val[2], 'a=1')
     assert val[3].startswith('expires')
 
+def test_set_cookie_expires_is_timedelta_and_max_age_is_None():
+    import datetime
+    res = Response()
+    then = datetime.timedelta(days=1)
+    res.set_cookie('a', '1', expires=then)
+    eq_(res.headerlist[-1][0], 'Set-Cookie')
+    val = [ x.strip() for x in res.headerlist[-1][1].split(';')]
+    assert len(val) == 4
+    val.sort()
+    ok_(val[0] in ('Max-Age=86399', 'Max-Age=86400'))
+    eq_(val[1], 'Path=/')
+    eq_(val[2], 'a=1')
+    assert val[3].startswith('expires')
+
 def test_set_cookie_value_is_unicode():
     res = Response()
     val = text_(b'La Pe\xc3\xb1a', 'utf-8')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -121,6 +121,11 @@ def test_cookies():
         ]
     )
 
+def test_unicode_cookies():
+    res = Response()
+    assert_raises(UnicodeEncodeError, Response.set_cookie, res, 'x',
+            text_(b'\N{BLACK SQUARE}', 'unicode_escape'))
+
 def test_http_only_cookie():
     req = Request.blank('/')
     res = req.get_response(Response('blah'))
@@ -696,12 +701,6 @@ def test_set_cookie_expires_is_timedelta_and_max_age_is_None():
     eq_(val[1], 'Path=/')
     eq_(val[2], 'a=1')
     assert val[3].startswith('expires')
-
-def test_set_cookie_value_is_unicode():
-    res = Response()
-    val = text_(b'La Pe\xc3\xb1a', 'utf-8')
-    res.set_cookie('a', val)
-    eq_(res.headerlist[-1], ('Set-Cookie', 'a="La Pe\\303\\261a"; Path=/'))
 
 def test_delete_cookie():
     res = Response()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -110,14 +110,14 @@ def test_init_content_type_w_charset():
 def test_cookies():
     res = Response()
     # test unicode value
-    res.set_cookie('x', text_(b'\N{BLACK SQUARE}', 'unicode_escape'))
+    res.set_cookie('x', "test")
     # utf8 encoded
-    eq_(res.headers.getall('set-cookie'), ['x="\\342\\226\\240"; Path=/'])
+    eq_(res.headers.getall('set-cookie'), ['x=test; Path=/'])
     r2 = res.merge_cookies(simple_app)
     r2 = BaseRequest.blank('/').get_response(r2)
     eq_(r2.headerlist,
         [('Content-Type', 'text/html; charset=utf8'),
-        ('Set-Cookie', 'x="\\342\\226\\240"; Path=/'),
+        ('Set-Cookie', 'x=test; Path=/'),
         ]
     )
 

--- a/webob/cookies.py
+++ b/webob/cookies.py
@@ -629,7 +629,7 @@ class CookieProfile(object):
         self.domains = domains
 
         if serializer is None:
-            serializer = JSONSerializer()
+            serializer = Base64Serializer()
 
         self.serializer = serializer
         self.request = None

--- a/webob/cookies.py
+++ b/webob/cookies.py
@@ -388,11 +388,13 @@ def _value_quote(v):
     # This looks scary, but is simple. We remove all valid characters from the
     # string, if we end up with leftovers (string is longer than 0, we have
     # invalid characters in our value)
-    if v.translate(None, _allowed_cookie_bytes):
+
+    leftovers = v.translate(None, _allowed_cookie_bytes)
+    if leftovers:
         __warn_or_raise(
                 "Cookie value contains invalid bytes: (%s). Future versions "
                 "will raise ValueError upon encountering invalid bytes." %
-                (v.translate(None, _allowed_cookie_bytes),),
+                (leftovers,),
                 DeprecationWarning, ValueError, 'Invalid characters in cookie value'
                 )
         #raise ValueError('Invalid characters in cookie value')

--- a/webob/cookies.py
+++ b/webob/cookies.py
@@ -395,7 +395,7 @@ def _value_quote(v):
                 "Cookie value contains invalid bytes: (%s). Future versions "
                 "will raise ValueError upon encountering invalid bytes." %
                 (leftovers,),
-                DeprecationWarning, ValueError, 'Invalid characters in cookie value'
+                RuntimeWarning, ValueError, 'Invalid characters in cookie value'
                 )
         #raise ValueError('Invalid characters in cookie value')
         return b'"' + b''.join(map(_escape_char, v)) + b'"'

--- a/webob/cookies.py
+++ b/webob/cookies.py
@@ -328,12 +328,12 @@ def _ch_unquote(m):
 # serializing
 #
 
-# these chars can be in cookie value w/o causing it to be quoted
-# see http://tools.ietf.org/html/rfc6265#section-4.1.1
-# and https://github.com/Pylons/webob/pull/104#issuecomment-28044314
+# these chars can be in cookie value see
+# http://tools.ietf.org/html/rfc6265#section-4.1.1 and
+# https://github.com/Pylons/webob/pull/104#issuecomment-28044314
 
-# allowed in cookie values without quoting:
-# <space> (0x21), "#$%&'()*+" (0x25-0x2B), "-./0123456789:" (0x2D-0x3A),
+# allowed in cookie values:
+# ! (0x21), "#$%&'()*+" (0x25-0x2B), "-./0123456789:" (0x2D-0x3A),
 # "<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[" (0x3C-0x5B),
 # "]^_`abcdefghijklmnopqrstuvwxyz{|}~" (0x5D-0x7E)
 

--- a/webob/response.py
+++ b/webob/response.py
@@ -789,7 +789,7 @@ class Response(object):
         m.httponly = httponly
         self.headerlist.append(('Set-Cookie', m.serialize()))
 
-    def delete_cookie(self, key, path='/', domain=None):
+    def delete_cookie(self, name, path='/', domain=None):
         """
         Delete a cookie from the client.  Note that path and domain must match
         how the cookie was originally set.
@@ -797,9 +797,9 @@ class Response(object):
         This sets the cookie to the empty string, and max_age=0 so
         that it should expire immediately.
         """
-        self.set_cookie(key, None, path=path, domain=domain)
+        self.set_cookie(name, None, path=path, domain=domain)
 
-    def unset_cookie(self, key, strict=True):
+    def unset_cookie(self, name, strict=True):
         """
         Unset a cookie with the given name (remove it from the
         response).
@@ -810,15 +810,15 @@ class Response(object):
         cookies = Cookie()
         for header in existing:
             cookies.load(header)
-        if isinstance(key, text_type):
-            key = key.encode('utf8')
-        if key in cookies:
-            del cookies[key]
+        if isinstance(name, text_type):
+            name = name.encode('utf8')
+        if name in cookies:
+            del cookies[name]
             del self.headers['Set-Cookie']
             for m in cookies.values():
                 self.headerlist.append(('Set-Cookie', m.serialize()))
         elif strict:
-            raise KeyError("No cookie has been set with the name %r" % key)
+            raise KeyError("No cookie has been set with the name %r" % name)
 
 
     def merge_cookies(self, resp):

--- a/webob/response.py
+++ b/webob/response.py
@@ -30,7 +30,6 @@ from webob.compat import (
 
 from webob.cookies import (
     Cookie,
-    Morsel,
     make_cookie,
     )
 
@@ -777,6 +776,8 @@ class Response(object):
         # expires can also be a datetime
         if not max_age and isinstance(expires, datetime):
             max_age = expires - datetime.utcnow()
+
+        value = bytes_(value, 'utf-8')
 
         cookie = make_cookie(name, value, max_age=max_age, path=path,
                 domain=domain, secure=secure, httponly=httponly,

--- a/webob/response.py
+++ b/webob/response.py
@@ -750,13 +750,14 @@ class Response(object):
 
         ``expires``
 
-           A ``datetime.timedelta`` object representing an amount of time or
-           the value ``None``.  A non-``None`` value is used to generate the
-           ``Expires`` value of the generated cookie.  If ``max_age`` is not
-           passed, but this value is not ``None``, it will influence the
-           ``Max-Age`` header (``Max-Age`` will be 'expires_value -
-           datetime.utcnow()').  If this value is ``None``, the ``Expires``
-           cookie value will be unset (unless ``max_age`` is also passed).
+           A ``datetime.timedelta`` object representing an amount of time,
+           ``datetime.datetime`` or ``None``. A non-``None`` value is used to
+           generate the ``Expires`` value of the generated cookie. If
+           ``max_age`` is not passed, but this value is not ``None``, it will
+           influence the ``Max-Age`` header. If this value is ``None``, the
+           ``Expires`` cookie value will be unset (unless ``max_age`` is set).
+           If ``max_age`` is set, it will be used to generate the ``expires``
+           and this value is ignored.
 
         ``overwrite``
 

--- a/webob/response.py
+++ b/webob/response.py
@@ -712,13 +712,14 @@ class Response(object):
 
         ``max_age``
 
-           An integer representing a number of seconds or ``None``.  If this
-           value is an integer, it is used as the ``Max-Age`` of the
-           generated cookie.  If ``expires`` is not passed and this value is
-           an integer, the ``max_age`` value will also influence the
-           ``Expires`` value of the cookie (``Expires`` will be set to now +
-           max_age).  If this value is ``None``, the cookie will not have a
-           ``Max-Age`` value (unless ``expires`` is also sent).
+           An integer representing a number of seconds, ``datetime.timedelta``,
+           or ``None``. This value is used as the ``Max-Age`` of the generated
+           cookie.  If ``expires`` is not passed and this value is not
+           ``None``, the ``max_age`` value will also influence the ``Expires``
+           value of the cookie (``Expires`` will be set to now + max_age).  If
+           this value is ``None``, the cookie will not have a ``Max-Age`` value
+           (unless ``expires`` is set). If both ``max_age`` and ``expires`` are
+           set, this value takes precedence.
 
         ``path``
 


### PR DESCRIPTION
This updates `response.set_cookie()` with proper documentation, and refactors it so that it uses `webob.cookies.make_cookie()` instead of it's own implementation, code-reuse for the win!

However, this does break backwards compatibility because we no longer allow unicode cookie values, these were technically contra-spec in the first place, and may not have been accepted by all browsers.

We also change from `key` to `name` because cookies have names. 

This fixes #166 and #171.

