### PR TITLE
Allow wildcards to be used when comparing a MIMEAccept against an offer

### DIFF
--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -314,7 +314,10 @@ def test_wildcard_matching():
         ('*/a', '*')]
     for mask, offer in matches:
         assert mimeaccept._match(mask, offer)
-
+        # Test malformed mask and offer variants where either is missing
+        # a type or subtype
+        assert mimeaccept._match('A', offer)
+        assert mimeaccept._match(mask, 'a')
 
     mismatches = [
         ('B/b', 'A/*'),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2444,7 +2444,6 @@ class TestRequest_functional(unittest.TestCase):
         self.assertTrue(not self._blankOne('/', headers={'Accept': ''}).accept)
         req = self._blankOne('/', headers={'Accept':'text/plain'})
         self.assertTrue(req.accept)
-        self.assertRaises(ValueError, req.accept.best_match, ['*/*'])
         req = self._blankOne('/', accept=['*/*','text/*'])
         self.assertEqual(
             req.accept.best_match(['application/x-foo', 'text/plain']),

--- a/webob/acceptparse.py
+++ b/webob/acceptparse.py
@@ -314,17 +314,19 @@ class MIMEAccept(Accept):
                 '*' == offer):
             return True
 
+        # Set mask type with wildcard subtype for malformed masks
         try:
             mask_type, mask_subtype = [x.lower() for x in mask.split('/')]
         except ValueError:
             mask_type = mask
-            mask_subtype = ''
+            mask_subtype = '*'
 
+        # Set offer type with wildcard subtype for malformed offers
         try:
             offer_type, offer_subtype = [x.lower() for x in offer.split('/')]
         except ValueError:
             offer_type = offer
-            offer_subtype = ''
+            offer_subtype = '*'
 
         if mask_subtype == '*':
             # match on type only
@@ -342,17 +344,11 @@ class MIMEAccept(Accept):
 
         if offer_subtype == '*':
             # match on type only
-            if mask_type == '*':
-                return True
-            else:
-                return mask_type.lower() == offer_type.lower()
+            return mask_type.lower() == offer_type.lower()
 
         if offer_type == '*':
             # match on subtype only
-            if mask_subtype == '*':
-                return True
-            else:
-                return mask_subtype.lower() == offer_subtype.lower()
+            return mask_subtype.lower() == offer_subtype.lower()
 
         return offer.lower() == mask.lower()
 


### PR DESCRIPTION
Primary motivation is to address https://github.com/Pylons/pyramid/issues/1407, which would enable usage of wildcards as an accept predicate:

```python
@view_config(accept='text/*')
def view(request):
    ...
```

`Webob.acceptparse.MIMEAccept` now supports the following, where previously an exception was raised:

```python
>>> accept = MIMEAccept('text/html')
>>> 'text/*' in accept
True
>>> '*/html' in accept
True
>>> '*' in accept
True
```

- Fixes #155
- Addresses https://github.com/Pylons/pyramid/issues/1407
