### PR TITLE
Support stale-while-revalidate and stale-if-error

### DIFF
--- a/webob/cachecontrol.py
+++ b/webob/cachecontrol.py
@@ -202,6 +202,9 @@ class CacheControl(object):
     max_age = value_property('max-age', none=-1)
     s_maxage = value_property('s-maxage', type='response')
     s_max_age = s_maxage
+    stale_while_revalidate = value_property(
+        'stale-while-revalidate', type='response')
+    stale_if_error = value_property('stale-if-error', type='response')
 
     def __str__(self):
         return serialize_cache_control(self.properties)


### PR DESCRIPTION
These supports the RFC 5861 extensions to cache control which allow a site to tell a HTTP cache that it's acceptable to serve a stale response while re-validating the currently cached response (``stale-if-revalidate``) and that it's acceptable to serve a stale response if an error occurs (``stale-if-error``). These both take a number of seconds for which it is acceptable to serve a stale response for.

I didn't write any tests because there doesn't seem to be any that exercise all of the various header options, if this needs tests let me know.