### PR TITLE
Use duck-typing to set a quasi-integer response status.

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -451,7 +451,7 @@ def test_set_status():
     res = Response()
     res.status = "200"
     eq_(res.status, "200 OK")
-    assert_raises(TypeError, setattr, res, 'status', float(200))
+    assert_raises(TypeError, setattr, res, 'status', (200,))
 
 def test_set_headerlist():
     res = Response()

--- a/webob/response.py
+++ b/webob/response.py
@@ -244,8 +244,12 @@ class Response(object):
         return self._status
 
     def _status__set(self, value):
-        if isinstance(value, int):
-            self.status_code = value
+        try:
+            code = int(value)
+        except ValueError:
+            pass
+        else:
+            self.status_code = code
             return
         if PY3: # pragma: no cover
             if isinstance(value, bytes):
@@ -256,11 +260,6 @@ class Response(object):
             raise TypeError(
                 "You must set status to a string or integer (not %s)"
                 % type(value))
-        if ' ' not in value:
-             try:
-                value += ' ' + status_reasons[int(value)]
-             except KeyError:
-                value += ' ' + status_generic_reasons[int(value) // 100]
         self._status = value
 
     status = property(_status__get, _status__set, doc=_status__get.__doc__)

--- a/webob/response.py
+++ b/webob/response.py
@@ -246,7 +246,7 @@ class Response(object):
     def _status__set(self, value):
         try:
             code = int(value)
-        except ValueError:
+        except (ValueError, TypeError):
             pass
         else:
             self.status_code = code


### PR DESCRIPTION
This change checks for integer values when setting `response.status` by calling `int()` on the supplied value, instead of explicitly checking for a subclass of `int`.

This is helpful to me, because I'm writing code that wraps HTTP statuses in a class that defines `__int__()`. I'd like to be able to use WebOb together with this class without having to check whether the Response object accepted the status, or whether I need to call `int()` (or `str()` for that matter) and try again.

This change additionally removes the need for the "`if ' ' not in value`" check, which assumed `value` was interpretable by `int()` anyway and then performed the same string substitution as the setter for `response.status_code`.