### PR TITLE
Replaced mentions of Accept.best_matches(...) for mentions of Accept.bes...

### DIFF
--- a/docs/differences.txt
+++ b/docs/differences.txt
@@ -28,7 +28,7 @@ Request
 
 ``languages()``:
     This is available through ``req.accept_language``, particularly
-    ``req.accept_language.best_matches(fallback_language)``
+    ``req.accept_language.best_match(supported_languages)``
 
 ``match_accept(mimetypes)``:
     This is available through ``req.accept.first_match(mimetypes)``;

--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -355,7 +355,7 @@ is preferred:
 
 .. code-block:: python
 
-    >>> req.accept.best_matches()
+    >>> list(req.accept)
     ['application/xhtml+xml', 'text/html']
 
 For languages you'll often have a "fallback" language.  E.g., if there's
@@ -365,10 +365,22 @@ any less preferrable languages):
 .. code-block:: python
 
     >>> req.accept_language = 'es, pt-BR'
-    >>> req.accept_language.best_matches('en-US')
-    ['es', 'pt-BR', 'en-US']
-    >>> req.accept_language.best_matches('es')
-    ['es']
+    >>> req.accept_language.best_match(['en-GB', 'en-US'], default_match='en-US')
+    'en-US'
+    >>> req.accept_language.best_match(['es', 'en-US'], default_match='en-US')
+    'es'
+
+Your fallback language must appear both in the ``offers`` and as the
+``default_match`` to insure that it is returned as a best match if the
+client specified a preference for it.
+
+.. code-block:: python
+
+    >>> req.accept_language = 'en-US;q=0.5, en-GB;q=0.2'
+    >>> req.accept_language.best_match(['en-GB'], default_match='en-US')
+    'en-GB'
+    >>> req.accept_language.best_match(['en-GB', 'en-US'], default_match='en-US')
+    'en-US'
 
 Conditional Requests
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/test_request.txt
+++ b/docs/test_request.txt
@@ -240,12 +240,15 @@ mime types are not supported.
     'es;q=0.7, en-US;q=0.5'
     >>> req.headers['Accept-Language']
     'es;q=0.7, en-US;q=0.5'
-    >>> req.accept_language.best_matches('en-GB')
-    ['es', 'en-US', 'en-GB']
-    >>> req.accept_language.best_matches('es')
-    ['es']
-    >>> req.accept_language.best_matches('ES')
-    ['ES']
+    >>> req.accept_language.best_match(['en-GB'])
+    >>> req.accept_language.best_match(['en-GB'], default_match='en-GB')
+    'en-GB'
+    >>> req.accept_language.best_match(['en-GB', 'en-US'], default_match='en-GB')
+    'en-US'
+    >>> req.accept_language.best_match(['es'])
+    'es'
+    >>> req.accept_language.best_match(['ES'])
+    'ES'
 
     >>> req = Request.blank('/', accept_language='en;q=0.5')
     >>> req.accept_language.best_match(['en-gb'])


### PR DESCRIPTION
...t_match(...), where applicable in the documentation. I obviously left the part about it getting deprecated in the News page of the doc. Fixes #107.