### PR TITLE
Don't add a charset if none is specified and the content-type is JSON.

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -104,6 +104,7 @@ def test_set_response_status_code_generic_reason():
     assert res.status_code == 299
     assert res.status == '299 Success'
 
+
 def test_content_type():
     r = Response()
     # default ctype and charset
@@ -120,6 +121,21 @@ def test_content_type():
 def test_init_content_type_w_charset():
     v = 'text/plain;charset=ISO-8859-1'
     eq_(Response(content_type=v).headers['content-type'], v)
+
+def test_init_adds_default_charset_when_not_json():
+    content_type = 'text/plain'
+    expected = 'text/plain; charset=UTF-8'
+    eq_(Response(content_type=content_type).headers['content-type'], expected)
+
+def test_init_no_charset_when_json():
+    content_type = 'application/json'
+    expected = content_type
+    eq_(Response(content_type=content_type).headers['content-type'], expected)
+
+def test_init_keeps_specified_charset_when_json():
+    content_type = 'application/json;charset=ISO-8859-1'
+    expected = content_type
+    eq_(Response(content_type=content_type).headers['content-type'], expected)
 
 
 def test_cookies():

--- a/webob/response.py
+++ b/webob/response.py
@@ -116,16 +116,13 @@ class Response(object):
         if 'charset' in kw:
             charset = kw.pop('charset')
         elif self.default_charset:
-            if (content_type
-                and 'charset=' not in content_type
-                and (content_type == 'text/html'
-                    or content_type.startswith('text/')
-                    or content_type.startswith('application/xml')
-                    or content_type.startswith('application/json')
-                    or (content_type.startswith('application/')
-                         and (content_type.endswith('+xml') or content_type.endswith('+json'))))):
-                charset = self.default_charset
-        if content_type and charset:
+            if content_type and 'charset=' not in content_type:
+                if (content_type == 'text/html'
+                        or content_type.startswith('text/')
+                        or _is_xml(content_type)
+                        or _is_json(content_type)):
+                    charset = self.default_charset
+        if content_type and charset and not _is_json(content_type):
             content_type += '; charset=' + charset
         elif self._headerlist and charset:
             self.charset = charset
@@ -1230,6 +1227,16 @@ class EmptyResponse(object):
         raise StopIteration()
 
     __next__ = next # py3
+
+def _is_json(content_type):
+    return (content_type.startswith('application/json')
+            or (content_type.startswith('application/')
+                and content_type.endswith('+json')))
+
+def _is_xml(content_type):
+    return (content_type.startswith('application/xml')
+            or (content_type.startswith('application/')
+                and content_type.endswith('+xml')))
 
 def _request_uri(environ):
     """Like wsgiref.url.request_uri, except eliminates :80 ports


### PR DESCRIPTION
Fixes #196. If a charset is already specified in the content-type, I opted to leave it there. Else, no charset will be added to the content-type line when the the effective content-type is JSON.

I also reworked the content-type-checking condition make it more legible.