### PR TITLE
Preserve wsgify default args

### DIFF
--- a/webob/dec.py
+++ b/webob/dec.py
@@ -124,10 +124,8 @@ class wsgify(object):
             req = self.RequestClass(environ)
             req.response = req.ResponseClass()
             try:
-                args = self.args
-                if self.middleware_wraps:
-                    args = (self.middleware_wraps,) + args
-                resp = self.call_func(req, *args, **self.kwargs)
+                args, kw = self._prepare_args(None, None)
+                resp = self.call_func(req, *args, **kw)
             except HTTPException as exc:
                 resp = exc
             if resp is None:
@@ -143,9 +141,8 @@ class wsgify(object):
                 resp = req.response.merge_cookies(resp)
             return resp(environ, start_response)
         else:
-            if self.middleware_wraps:
-                args = (self.middleware_wraps,) + args
-            return self.func(req, *args, **kw)
+            args, kw = self._prepare_args(args, kw)
+            return self.call_func(req, *args, **kw)
 
     def get(self, url, **kw):
         """Run a GET request on this application, returning a Response.
@@ -258,6 +255,13 @@ class wsgify(object):
         if app is None:
             return _MiddlewareFactory(cls, middle_func, kw)
         return cls(middle_func, middleware_wraps=app, kwargs=kw)
+
+    def _prepare_args(self, args, kwargs):
+        args = args or self.args
+        kwargs = kwargs or self.kwargs
+        if self.middleware_wraps:
+            args = (self.middleware_wraps,) + args
+        return args, kwargs
 
 class _UnboundMiddleware(object):
     """A `wsgify.middleware` invocation that has not yet wrapped a


### PR DESCRIPTION
wsgify objects can be created with args/kwargs at construction time:

``` python
def hello(req, name):
    return "Hello, %s!" % name
app = wsgify(hello, args=("Fred",))
```

Previously, these arguments would only be passed to the underlying
function (here, `hello`) when using the wsgify object as a callable that
accepts `(environ, start_response)`. If you used the object as a
callable taking a request (as documented) then the default args would be
discarded.

That is, continuing the above example:

``` python
req = Request.blank('/')
resp = req.get_response(app)  # => "Hello, Fred"
```

BUT

``` python
app(req)                      # => raises TypeError
```

This is perhaps most confusing when it interacts with
`wsgify.middleware`. For example:

``` python
@wsgify.middleware
def add_magic_header(req, app, value='seated ducks'):
    resp = req.get_response(app)
    resp.headers['Magic-Header'] = value
    return resp

app = add_magic_header(app, value='flying elephants')

resp1 = req.get_response(app)
resp2 = app(req)

resp1.headers['Magic-Header']  # => 'flying elephants'
resp2.headers['Magic-Header']  # => 'seated ducks'
```

(An executable example of the above [can be found here](https://gist.github.com/nickstenning/ee09674bc6dced0be64d).)

This pull request ensures that if variadic arguments or keyword arguments are
not provided in a call like

``` python
app(req)
```

then the defaults are used.
