### PR TITLE
Ensure that webob.exc.status_map is deterministic.

### DIFF
--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -1,52 +1,45 @@
 from webob.request import Request
 from webob.dec import wsgify
-from webob.exc import no_escape
-from webob.exc import strip_tags
-from webob.exc import HTTPException
-from webob.exc import WSGIHTTPException
-from webob.exc import _HTTPMove
-from webob.exc import HTTPMethodNotAllowed
-from webob.exc import HTTPExceptionMiddleware
-from webob.exc import status_map
+from webob import exc as webob_exc
 
 from nose.tools import eq_, ok_, assert_equal, assert_raises
 
 @wsgify
 def method_not_allowed_app(req):
     if req.method != 'GET':
-        raise HTTPMethodNotAllowed()
+        raise webob_exc.HTTPMethodNotAllowed()
     return 'hello!'
 
 def test_noescape_null():
-    assert_equal(no_escape(None), '')
+    assert_equal(webob_exc.no_escape(None), '')
 
 def test_noescape_not_basestring():
-    assert_equal(no_escape(42), '42')
+    assert_equal(webob_exc.no_escape(42), '42')
 
 def test_noescape_unicode():
     class DummyUnicodeObject(object):
         def __unicode__(self):
             return '42'
     duo = DummyUnicodeObject()
-    assert_equal(no_escape(duo), '42')
+    assert_equal(webob_exc.no_escape(duo), '42')
 
 def test_strip_tags_empty():
-    assert_equal(strip_tags(''), '')
+    assert_equal(webob_exc.strip_tags(''), '')
 
 def test_strip_tags_newline_to_space():
-    assert_equal(strip_tags('a\nb'), 'a b')
+    assert_equal(webob_exc.strip_tags('a\nb'), 'a b')
 
 def test_strip_tags_zaps_carriage_return():
-    assert_equal(strip_tags('a\rb'), 'ab')
+    assert_equal(webob_exc.strip_tags('a\rb'), 'ab')
 
 def test_strip_tags_br_to_newline():
-    assert_equal(strip_tags('a<br/>b'), 'a\nb')
+    assert_equal(webob_exc.strip_tags('a<br/>b'), 'a\nb')
 
 def test_strip_tags_zaps_comments():
-    assert_equal(strip_tags('a<!--b-->'), 'ab')
+    assert_equal(webob_exc.strip_tags('a<!--b-->'), 'ab')
 
 def test_strip_tags_zaps_tags():
-    assert_equal(strip_tags('foo<bar>baz</bar>'), 'foobaz')
+    assert_equal(webob_exc.strip_tags('foo<bar>baz</bar>'), 'foobaz')
 
 def test_HTTPException():
     import warnings
@@ -57,7 +50,7 @@ def test_HTTPException():
         return _result
     environ = {}
     start_response = object()
-    exc = HTTPException('testing', _response)
+    exc = webob_exc.HTTPException('testing', _response)
     ok_(exc.wsgi_response is _response)
     result = exc(environ, start_response)
     ok_(result is result)
@@ -69,7 +62,7 @@ def test_exception_with_unicode_data():
     assert res.status_code == 405
 
 def test_WSGIHTTPException_headers():
-    exc = WSGIHTTPException(headers=[('Set-Cookie', 'a=1'),
+    exc = webob_exc.WSGIHTTPException(headers=[('Set-Cookie', 'a=1'),
                                      ('Set-Cookie', 'a=2')])
     mixed = exc.headers.mixed()
     assert mixed['set-cookie'] ==  ['a=1', 'a=2']
@@ -77,28 +70,28 @@ def test_WSGIHTTPException_headers():
 def test_WSGIHTTPException_w_body_template():
     from string import Template
     TEMPLATE = '$foo: $bar'
-    exc = WSGIHTTPException(body_template = TEMPLATE)
+    exc = webob_exc.WSGIHTTPException(body_template = TEMPLATE)
     assert_equal(exc.body_template, TEMPLATE)
     ok_(isinstance(exc.body_template_obj, Template))
     eq_(exc.body_template_obj.substitute({'foo': 'FOO', 'bar': 'BAR'}),
         'FOO: BAR')
 
 def test_WSGIHTTPException_w_empty_body():
-    class EmptyOnly(WSGIHTTPException):
+    class EmptyOnly(webob_exc.WSGIHTTPException):
         empty_body = True
     exc = EmptyOnly(content_type='text/plain', content_length=234)
     ok_('content_type' not in exc.__dict__)
     ok_('content_length' not in exc.__dict__)
 
 def test_WSGIHTTPException___str__():
-    exc1 = WSGIHTTPException(detail='Detail')
+    exc1 = webob_exc.WSGIHTTPException(detail='Detail')
     eq_(str(exc1), 'Detail')
-    class Explain(WSGIHTTPException):
+    class Explain(webob_exc.WSGIHTTPException):
         explanation = 'Explanation'
     eq_(str(Explain()), 'Explanation')
 
 def test_WSGIHTTPException_plain_body_no_comment():
-    class Explain(WSGIHTTPException):
+    class Explain(webob_exc.WSGIHTTPException):
         code = '999'
         title = 'Testing'
         explanation = 'Explanation'
@@ -107,7 +100,7 @@ def test_WSGIHTTPException_plain_body_no_comment():
         '999 Testing\n\nExplanation\n\n Detail  ')
 
 def test_WSGIHTTPException_html_body_w_comment():
-    class Explain(WSGIHTTPException):
+    class Explain(webob_exc.WSGIHTTPException):
         code = '999'
         title = 'Testing'
         explanation = 'Explanation'
@@ -136,7 +129,7 @@ def test_WSGIHTTPException_generate_response():
        'REQUEST_METHOD': 'PUT',
        'HTTP_ACCEPT': 'text/html'
     }
-    excep = WSGIHTTPException()
+    excep = webob_exc.WSGIHTTPException()
     assert_equal( excep(environ,start_response), [
         b'<html>\n'
         b' <head>\n'
@@ -160,7 +153,7 @@ def test_WSGIHTTPException_call_w_body():
        'SERVER_PORT': '80',
        'REQUEST_METHOD': 'PUT'
     }
-    excep = WSGIHTTPException()
+    excep = webob_exc.WSGIHTTPException()
     excep.body = b'test'
     assert_equal( excep(environ,start_response), [b'test'] )
 
@@ -174,7 +167,7 @@ def test_WSGIHTTPException_wsgi_response():
        'SERVER_PORT': '80',
        'REQUEST_METHOD': 'HEAD'
     }
-    excep = WSGIHTTPException()
+    excep = webob_exc.WSGIHTTPException()
     assert_equal( excep.wsgi_response(environ,start_response), [] )
 
 def test_WSGIHTTPException_exception_newstyle():
@@ -186,9 +179,8 @@ def test_WSGIHTTPException_exception_newstyle():
        'SERVER_PORT': '80',
        'REQUEST_METHOD': 'HEAD'
     }
-    excep = WSGIHTTPException()
-    from webob import exc
-    exc.newstyle_exceptions = True
+    excep = webob_exc.WSGIHTTPException()
+    webob_exc.newstyle_exceptions = True
     assert_equal( excep(environ,start_response), [] )
 
 def test_WSGIHTTPException_exception_no_newstyle():
@@ -200,9 +192,8 @@ def test_WSGIHTTPException_exception_no_newstyle():
        'SERVER_PORT': '80',
        'REQUEST_METHOD': 'HEAD'
     }
-    excep = WSGIHTTPException()
-    from webob import exc
-    exc.newstyle_exceptions = False
+    excep = webob_exc.WSGIHTTPException()
+    webob_exc.newstyle_exceptions = False
     assert_equal( excep(environ,start_response), [] )
 
 def test_HTTPOk_head_of_proxied_head():
@@ -233,7 +224,7 @@ def test_HTTPOk_head_of_proxied_head():
     # Copy the response like a proxy server would.
     # Copying an empty body has set content_length
     # so copy the headers only afterwards.
-    resp2 = status_map[resp1.status_int](request=req)
+    resp2 = webob_exc.status_map[resp1.status_int](request=req)
     resp2.body = resp1.body
     resp2.headerlist = resp1.headerlist
     verify_response(resp2, "copied response")
@@ -252,7 +243,7 @@ def test_HTTPMove():
        'REQUEST_METHOD': 'HEAD',
        'PATH_INFO': '/',
     }
-    m = _HTTPMove()
+    m = webob_exc._HTTPMove()
     assert_equal( m( environ, start_response ), [] )
 
 def test_HTTPMove_location_not_none():
@@ -265,13 +256,13 @@ def test_HTTPMove_location_not_none():
        'REQUEST_METHOD': 'HEAD',
        'PATH_INFO': '/',
     }
-    m = _HTTPMove(location='http://example.com')
+    m = webob_exc._HTTPMove(location='http://example.com')
     assert_equal( m( environ, start_response ), [] )
 
 def test_HTTPMove_add_slash_and_location():
     def start_response(status, headers, exc_info=None):
         pass
-    assert_raises( TypeError, _HTTPMove, location='http://example.com',
+    assert_raises( TypeError, webob_exc._HTTPMove, location='http://example.com',
                    add_slash=True )
 
 def test_HTTPMove_call_add_slash():
@@ -284,7 +275,7 @@ def test_HTTPMove_call_add_slash():
        'REQUEST_METHOD': 'HEAD',
        'PATH_INFO': '/',
     }
-    m = _HTTPMove()
+    m = webob_exc._HTTPMove()
     m.add_slash = True
     assert_equal( m( environ, start_response ), [] )
 
@@ -297,7 +288,7 @@ def test_HTTPMove_call_query_string():
        'SERVER_PORT': '80',
        'REQUEST_METHOD': 'HEAD'
     }
-    m = _HTTPMove()
+    m = webob_exc._HTTPMove()
     m.add_slash = True
     environ[ 'QUERY_STRING' ] = 'querystring'
     environ['PATH_INFO'] = '/'
@@ -307,7 +298,7 @@ def test_HTTPExceptionMiddleware_ok():
     def app( environ, start_response ):
         return '123'
     application = app
-    m = HTTPExceptionMiddleware(application)
+    m = webob_exc.HTTPExceptionMiddleware(application)
     environ = {}
     start_response = None
     res = m( environ, start_response )
@@ -317,9 +308,9 @@ def test_HTTPExceptionMiddleware_exception():
     def wsgi_response( environ, start_response):
         return '123'
     def app( environ, start_response ):
-        raise HTTPException( None, wsgi_response )
+        raise webob_exc.HTTPException( None, wsgi_response )
     application = app
-    m = HTTPExceptionMiddleware(application)
+    m = webob_exc.HTTPExceptionMiddleware(application)
     environ = {}
     start_response = None
     res = m( environ, start_response )
@@ -332,17 +323,67 @@ def test_HTTPExceptionMiddleware_exception_exc_info_none():
     def wsgi_response( environ, start_response):
         return start_response('200 OK', [], exc_info=None)
     def app( environ, start_response ):
-        raise HTTPException( None, wsgi_response )
+        raise webob_exc.HTTPException( None, wsgi_response )
     application = app
-    m = HTTPExceptionMiddleware(application)
+    m = webob_exc.HTTPExceptionMiddleware(application)
     environ = {}
     def start_response(status, headers, exc_info):
         pass
     try:
-        from webob import exc
-        old_sys = exc.sys
+        old_sys = webob_exc.sys
         sys = DummySys()
         res = m( environ, start_response )
         assert_equal( res, None )
     finally:
-        exc.sys = old_sys
+        webob_exc.sys = old_sys
+
+def test_status_map_is_deterministic():
+    for code, cls in (
+        (200, webob_exc.HTTPOk),
+        (201, webob_exc.HTTPCreated),
+        (202, webob_exc.HTTPAccepted),
+        (203, webob_exc.HTTPNonAuthoritativeInformation),
+        (204, webob_exc.HTTPNoContent),
+        (205, webob_exc.HTTPResetContent),
+        (206, webob_exc.HTTPPartialContent),
+        (300, webob_exc.HTTPMultipleChoices),
+        (301, webob_exc.HTTPMovedPermanently),
+        (302, webob_exc.HTTPFound),
+        (303, webob_exc.HTTPSeeOther),
+        (304, webob_exc.HTTPNotModified),
+        (305, webob_exc.HTTPUseProxy),
+        (307, webob_exc.HTTPTemporaryRedirect),
+        (400, webob_exc.HTTPBadRequest),
+        (401, webob_exc.HTTPUnauthorized),
+        (402, webob_exc.HTTPPaymentRequired),
+        (403, webob_exc.HTTPForbidden),
+        (404, webob_exc.HTTPNotFound),
+        (405, webob_exc.HTTPMethodNotAllowed),
+        (406, webob_exc.HTTPNotAcceptable),
+        (407, webob_exc.HTTPProxyAuthenticationRequired),
+        (408, webob_exc.HTTPRequestTimeout),
+        (409, webob_exc.HTTPConflict),
+        (410, webob_exc.HTTPGone),
+        (411, webob_exc.HTTPLengthRequired),
+        (412, webob_exc.HTTPPreconditionFailed),
+        (413, webob_exc.HTTPRequestEntityTooLarge),
+        (414, webob_exc.HTTPRequestURITooLong),
+        (415, webob_exc.HTTPUnsupportedMediaType),
+        (416, webob_exc.HTTPRequestRangeNotSatisfiable),
+        (417, webob_exc.HTTPExpectationFailed),
+        (422, webob_exc.HTTPUnprocessableEntity),
+        (423, webob_exc.HTTPLocked),
+        (424, webob_exc.HTTPFailedDependency),
+        (428, webob_exc.HTTPPreconditionRequired),
+        (429, webob_exc.HTTPTooManyRequests),
+        (431, webob_exc.HTTPRequestHeaderFieldsTooLarge),
+        (451, webob_exc.HTTPUnavailableForLegalReasons),
+        (500, webob_exc.HTTPInternalServerError),
+        (501, webob_exc.HTTPNotImplemented),
+        (502, webob_exc.HTTPBadGateway),
+        (503, webob_exc.HTTPServiceUnavailable),
+        (504, webob_exc.HTTPGatewayTimeout),
+        (505, webob_exc.HTTPVersionNotSupported),
+        (511, webob_exc.HTTPNetworkAuthenticationRequired),
+    ):
+        assert webob_exc.status_map[code] == cls

--- a/webob/exc.py
+++ b/webob/exc.py
@@ -1144,7 +1144,14 @@ for name, value in list(globals().items()):
         issubclass(value, HTTPException)
         and not name.startswith('_')):
         __all__.append(name)
-        if getattr(value, 'code', None):
+        if all((
+            getattr(value, 'code', None),
+            value not in (HTTPRedirection, HTTPClientError, HTTPServerError),
+            issubclass(
+                value,
+                (HTTPOk, HTTPRedirection, HTTPClientError, HTTPServerError)
+            )
+        )):
             status_map[value.code]=value
         if hasattr(value, 'explanation'):
             value.explanation = ' '.join(value.explanation.strip().split())


### PR DESCRIPTION
Because multiple base classes share and inherit the same status code, the
values of `webob.exc.status_map` are *not* deterministic at import time.  For
example, for any given Python process, `webob.exc.status_map[500]` might
be equal to any of the following:

    * WSGIHTTPException
    * HTTPServerError
    * HTTPError
    * HTTPInternalServerError
    * HTTPRedirection