### PR TITLE
Handle PATCH missing content type in req.POST.

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -500,6 +500,19 @@ class TestRequestCommon(unittest.TestCase):
         self.assertTrue(result.reason.startswith(
                                         'Not an HTML form submission'))
 
+    def test_PATCH_missing_content_type(self):
+        from webob.multidict import NoVars
+        data = b'input'
+        INPUT = BytesIO(data)
+        environ = {'wsgi.input': INPUT,
+                   'REQUEST_METHOD': 'PATCH',
+                  }
+        req = self._makeOne(environ)
+        result = req.POST
+        self.assertTrue(isinstance(result, NoVars))
+        self.assertTrue(result.reason.startswith(
+                                        'Not an HTML form submission'))
+
     def test_POST_missing_content_type(self):
         data = b'var1=value1&var2=value2&rep=1&rep=2'
         INPUT = BytesIO(data)

--- a/webob/request.py
+++ b/webob/request.py
@@ -775,7 +775,7 @@ class BaseRequest(object):
             if body_file is self.body_file_raw:
                 return vars
         content_type = self.content_type
-        if ((self.method == 'PUT' and not content_type)
+        if ((self.method != 'POST' and not content_type)
             or content_type not in
                 ('',
                  'application/x-www-form-urlencoded',


### PR DESCRIPTION
Avoids `TypeError: must be str, not bytes`.

Needed for 1.4, 1.5 and master branches.