### PR TITLE
Allow content-length to be unset with app_iter

### DIFF
--- a/tests/test_byterange.py
+++ b/tests/test_byterange.py
@@ -23,7 +23,6 @@ def test_range_parse():
 
 def test_range_content_range_length_none():
     range = Range(0, 100)
-    eq_(range.content_range(None), None)
     assert isinstance(range.content_range(1), ContentRange)
     eq_(tuple(range.content_range(1)), (0,1,1))
     eq_(tuple(range.content_range(200)), (0,100,200))

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -390,6 +390,13 @@ def test_content_length():
     eq_(r5.body, b'xxxxx')
     eq_(r5.content_length, 5)
 
+def test_app_iter_range_no_content_length():
+    req = Request.blank('/', range=(2,5))
+    r = Response(conditional_response=True)
+    r.app_iter=[b'012', b'34', b'5']
+    res = req.get_response(r)
+    eq_(res.body, b'234')
+
 def test_app_iter_range():
     req = Request.blank('/', range=(2,5))
     for app_iter in [

--- a/webob/byterange.py
+++ b/webob/byterange.py
@@ -44,6 +44,8 @@ class Range(object):
 
             Though it's still up to you to actually serve that content range!
         """
+        if length is None:
+            length = self.end
         range = self.range_for_length(length)
         if range is None:
             return None

--- a/webob/response.py
+++ b/webob/response.py
@@ -1083,7 +1083,6 @@ class Response(object):
             and self.content_range is None
             and method in ('HEAD', 'GET')
             and self.status_code == 200
-            and self.content_length is not None
         ):
             content_range = req.range.content_range(self.content_length)
             if content_range is None:


### PR DESCRIPTION
When using an app_iter it is sometimes desireable to not set
content-length (if you, for example, do not know what your content
length is).