### PR TITLE
Add extra security checks for Headers

### DIFF
--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -155,6 +155,14 @@ def test_header_getter_fset_text():
     desc.fset(resp, text_('avalue'))
     eq_(desc.fget(resp), 'avalue')
 
+def test_header_getter_fset_text_control_chars():
+    from webob.compat import text_
+    from webob.descriptors import header_getter
+    from webob import Response
+    resp = Response('aresp')
+    desc = header_getter('AHEADER', '14.3')
+    assert_raises(ValueError, desc.fset, resp, text_('\n'))
+
 def test_header_getter_fdel():
     from webob.descriptors import header_getter
     from webob import Response

--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -259,6 +259,17 @@ def test_HTTPMove_location_not_none():
     m = webob_exc._HTTPMove(location='http://example.com')
     assert_equal( m( environ, start_response ), [] )
 
+def test_HTTPMove_location_newlines():
+    environ = {
+       'wsgi.url_scheme': 'HTTP',
+       'SERVER_NAME': 'localhost',
+       'SERVER_PORT': '80',
+       'REQUEST_METHOD': 'HEAD',
+       'PATH_INFO': '/',
+    }
+    assert_raises(ValueError, webob_exc._HTTPMove,
+            location='http://example.com\r\nX-Test: false')
+
 def test_HTTPMove_add_slash_and_location():
     def start_response(status, headers, exc_info=None):
         pass

--- a/webob/descriptors.py
+++ b/webob/descriptors.py
@@ -138,6 +138,9 @@ def header_getter(header, rfc_section):
     def fset(r, value):
         fdel(r)
         if value is not None:
+            if '\n' in value or '\r' in value:
+                raise ValueError('Header value may not contain control characters')
+
             if isinstance(value, text_type) and not PY3:
                 value = value.encode('latin-1')
             r._headerlist.append((header, value))

--- a/webob/exc.py
+++ b/webob/exc.py
@@ -481,6 +481,9 @@ ${html_comment}''')
             detail=detail, headers=headers, comment=comment,
             body_template=body_template)
         if location is not None:
+            if '\n' in location or '\r' in location:
+                raise ValueError('Control characters are not allowed in location')
+
             self.location = location
             if add_slash:
                 raise TypeError(


### PR DESCRIPTION
This adds a sort of seatbelt that makes sure that applications using WebOb are less likely to be vulnerable to HTTP response splitting. Unfortunately due to the flexibility of WebOb it is difficult to guarantee that you can't add a header that is vulnerable, but this adds one more line of defense.

Closes #217