### PR TITLE
Request authorization avoid raise

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,9 @@ Bugfix
   https://github.com/Pylons/webob/pull/197 and
   https://github.com/Pylons/pyramid/issues/1611
 
+- Request.authorization would raise ValueError for unusual or malformed header
+  values. See https://github.com/Pylons/webob/issues/231
+
 Features
 ~~~~~~~~
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -650,15 +650,15 @@ def test_serialize_auth_str():
 
 def test_serialize_auth_parsed_emptystr():
     from webob.descriptors import serialize_auth
-    eq_(serialize_auth(('', '')), '')
+    eq_(serialize_auth(('', '')), ' ')
 
 def test_serialize_auth_parsed_unknown_nospace():
     from webob.descriptors import serialize_auth
-    eq_(serialize_auth(('NoSpace', '')), 'NoSpace')
+    eq_(serialize_auth(('NoSpace', '')), 'NoSpace ')
 
 def test_serialize_auth_parsed_known_nospace():
     from webob.descriptors import serialize_auth
-    eq_(serialize_auth(('Digest', {})), 'Digest')
+    eq_(serialize_auth(('Digest', {})), 'Digest ')
 
 def test_serialize_auth_basic_quoted():
     from webob.descriptors import serialize_auth

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -608,7 +608,15 @@ def test_parse_auth_none():
 
 def test_parse_auth_emptystr():
     from webob.descriptors import parse_auth
-    assert_raises(ValueError, parse_auth, '')
+    eq_(parse_auth(''), ('', ''))
+
+def test_parse_auth_unknown_nospace():
+    from webob.descriptors import parse_auth
+    eq_(parse_auth('NoSpace'), ('NoSpace', ''))
+
+def test_parse_auth_known_nospace():
+    from webob.descriptors import parse_auth
+    eq_(parse_auth('Digest'), ('Digest', {}))
 
 def test_parse_auth_basic():
     from webob.descriptors import parse_auth
@@ -635,6 +643,22 @@ def test_serialize_auth_none():
 def test_serialize_auth_emptystr():
     from webob.descriptors import serialize_auth
     eq_(serialize_auth(''), '')
+
+def test_serialize_auth_str():
+    from webob.descriptors import serialize_auth
+    eq_(serialize_auth('some string'), 'some string')
+
+def test_serialize_auth_parsed_emptystr():
+    from webob.descriptors import serialize_auth
+    eq_(serialize_auth(('', '')), '')
+
+def test_serialize_auth_parsed_unknown_nospace():
+    from webob.descriptors import serialize_auth
+    eq_(serialize_auth(('NoSpace', '')), 'NoSpace')
+
+def test_serialize_auth_parsed_known_nospace():
+    from webob.descriptors import serialize_auth
+    eq_(serialize_auth(('Digest', {})), 'Digest')
 
 def test_serialize_auth_basic_quoted():
     from webob.descriptors import serialize_auth

--- a/webob/descriptors.py
+++ b/webob/descriptors.py
@@ -334,8 +334,6 @@ def parse_auth(val):
 def serialize_auth(val):
     if isinstance(val, (tuple, list)):
         authtype, params = val
-        if not params:
-            return authtype
         if isinstance(params, dict):
             params = ', '.join(map('%s="%s"'.__mod__, params.items()))
         assert isinstance(params, str)

--- a/webob/descriptors.py
+++ b/webob/descriptors.py
@@ -321,7 +321,7 @@ known_auth_schemes = dict.fromkeys(known_auth_schemes, None)
 
 def parse_auth(val):
     if val is not None:
-        authtype, params = val.split(' ', 1)
+        authtype, sep, params = val.partition(' ')
         if authtype in known_auth_schemes:
             if authtype == 'Basic' and '"' not in params:
                 # this is the "Authentication: Basic XXXXX==" case
@@ -334,6 +334,8 @@ def parse_auth(val):
 def serialize_auth(val):
     if isinstance(val, (tuple, list)):
         authtype, params = val
+        if not params:
+            return authtype
         if isinstance(params, dict):
             params = ', '.join(map('%s="%s"'.__mod__, params.items()))
         assert isinstance(params, str)


### PR DESCRIPTION
Request.authorization would raise ValueError for unusual or malformed header values. See https://github.com/Pylons/webob/issues/231
