### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,14 +20,14 @@ parse HTTP responses.
 Support and Documentation
 -------------------------
 
-See the `WebOb Documentation website <http://webob.readthedocs.org/>`_ to view
+See the `WebOb Documentation website <https://webob.readthedocs.io/>`_ to view
 documentation, report bugs, and obtain support.
 
 License
 -------
 
 WebOb is offered under the `MIT-license
-<http://webob.readthedocs.org/en/latest/license.html>`_.
+<https://webob.readthedocs.io/en/latest/license.html>`_.
 
 Authors
 -------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.