### PR TITLE
Improve charset defaults in Response

### DIFF
--- a/docs/whatsnew-1.6.txt
+++ b/docs/whatsnew-1.6.txt
@@ -65,8 +65,17 @@ Bugfixes
   https://github.com/Pylons/webob/pull/183 for more information.
 
 - The application/json media type does not allow for a charset as discovery of
-  the encoding is done at the JSON layer. Upon initialization of a Response
-  WebOb will no longer add a charset if the content-type is set to JSON. See
-  https://github.com/Pylons/webob/pull/197 and
+  the encoding is done at the JSON layer, and it must always be UTF-{8,16,32}.
+  See the IANA spec at
+  https://www.iana.org/assignments/media-types/application/json, which notes
+
+    No "charset" parameter is defined for this registration.
+    Adding one really has no effect on compliant recipients.
+
+  RFC4627 describes the method for encoding discovery using the JSON content
+  itself. Upon initialization of a Response WebOb will no longer add a charset
+  if the content-type is set to JSON. See
+  https://github.com/Pylons/webob/pull/197,
+  https://github.com/Pylons/webob/issues/237 and
   https://github.com/Pylons/pyramid/issues/1611
 

--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -139,6 +139,8 @@ def test_WSGIHTTPException_respects_application_json():
         title = 'Validation Failed'
         explanation = 'Validation of an attribute failed.'
     def start_response(status, headers, exc_info=None):
+        # check that json doesn't contain a charset
+        assert ('Content-Type', 'application/json') in headers
         pass
 
     exc = ValidationError(detail='Attribute "xyz" is invalid.')
@@ -216,6 +218,7 @@ def test_WSGIHTTPException_allows_custom_json_formatter():
 
 def test_WSGIHTTPException_generate_response():
     def start_response(status, headers, exc_info=None):
+        assert ('Content-Type', 'text/html; charset=UTF-8') in headers
         pass
     environ = {
        'wsgi.url_scheme': 'HTTP',

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3265,9 +3265,9 @@ class TestRequest_functional(object):
     def test_call_WSGI_app(self):
         req = self._blankOne('/')
         def wsgi_app(environ, start_response):
-            start_response('200 OK', [('Content-type', 'text/plain')])
+            start_response('200 OK', [('Content-Type', 'text/plain')])
             return [b'Hi!']
-        assert req.call_application(wsgi_app) == ('200 OK', [('Content-type', 'text/plain')], [b'Hi!'])
+        assert req.call_application(wsgi_app) == ('200 OK', [('Content-Type', 'text/plain')], [b'Hi!'])
 
         res = req.get_response(wsgi_app)
         from webob.response import Response
@@ -3275,13 +3275,13 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-type', 'text/plain')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
         assert res.body == b'Hi!'
 
     def test_get_response_catch_exc_info_true(self):
         req = self._blankOne('/')
         def wsgi_app(environ, start_response):
-            start_response('200 OK', [('Content-type', 'text/plain')])
+            start_response('200 OK', [('Content-Type', 'text/plain')])
             return [b'Hi!']
         res = req.get_response(wsgi_app, catch_exc_info=True)
         from webob.response import Response
@@ -3289,7 +3289,7 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-type', 'text/plain')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
         assert res.body == b'Hi!'
 
     def equal_req(self, req, inp):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -60,6 +60,7 @@ def test_response():
     del req.environ
     with pytest.raises(TypeError):
         Response(charset=None,
+                 content_type='image/jpeg',
                  body=text_(b"unicode body"))
     with pytest.raises(TypeError):
         Response(wrong_key='dummy')
@@ -139,6 +140,15 @@ def test_init_keeps_specified_charset_when_json():
     content_type = 'application/json;charset=ISO-8859-1'
     expected = content_type
     assert Response(content_type=content_type).headers['content-type'] == expected
+
+def test_set_charset_fails_when_json():
+    content_type = 'application/json'
+    expected = content_type
+    res = Response(content_type=content_type)
+    res.charset = 'utf-8'
+    assert res.headers['content-type'] == expected
+    res.content_type_params = {'charset': 'utf-8'}
+    assert res.headers['content-type'] == expected
 
 
 def test_cookies():

--- a/webob/exc.py
+++ b/webob/exc.py
@@ -338,14 +338,10 @@ ${body}''')
         else:
             content_type = 'text/plain'
             body = self.plain_body(environ)
-        extra_kw = {}
-        if isinstance(body, text_type):
-            extra_kw.update(charset='utf-8')
         resp = Response(body,
                         status=self.status,
                         headerlist=headerlist,
                         content_type=content_type,
-                        **extra_kw
                         )
         resp.content_type = content_type
         return resp(environ, start_response)

--- a/webob/response.py
+++ b/webob/response.py
@@ -105,29 +105,34 @@ class Response(object):
             self._status = '200 OK'
         else:
             self.status = status
+        # initialize headers, content_type, and charset
+        self._headers = None
         if headerlist is None:
             self._headerlist = []
         else:
             self._headerlist = headerlist
-        self._headers = None
-        if content_type is None:
-            content_type = self.default_content_type
-        charset = None
-        if 'charset' in kw:
-            charset = kw.pop('charset')
-        elif self.default_charset:
-            if content_type and 'charset=' not in content_type:
-                if (content_type == 'text/html'
+        content_type = content_type or self.headers.get('Content-Type') or \
+                self.default_content_type
+        if 'Content-Type' not in self.headers:
+            self.headers['Content-Type'] = content_type
+        charset = kw.get('charset')
+        if content_type:
+            if charset:
+                self.charset = charset
+            elif self.default_charset:
+                charset_match = CHARSET_RE.search(content_type)
+                if charset_match:
+                    charset = self.charset
+                elif (content_type == 'text/html'
                         or content_type.startswith('text/')
-                        or _is_xml(content_type)
-                        or _is_json(content_type)):
+                        or _is_xml(content_type)):
                     charset = self.default_charset
-        if content_type and charset and not _is_json(content_type):
-            content_type += '; charset=' + charset
-        elif self._headerlist and charset:
-            self.charset = charset
-        if not self._headerlist and content_type:
-            self._headerlist.append(('Content-Type', content_type))
+                    self.charset = charset
+                elif _is_json(content_type):
+                    # don't set charset on the Content-Type for standards
+                    # compliance, but still need it locally to encode body text
+                    self.charset = None
+                    charset = self.default_charset
         if conditional_response is None:
             self.conditional_response = self.default_conditional_response
         else:
@@ -140,10 +145,7 @@ class Response(object):
                         "charset")
                 body = body.encode(charset)
             app_iter = [body]
-            if headerlist is None:
-                self._headerlist.append(('Content-Length', str(len(body))))
-            else:
-                self.headers['Content-Length'] = str(len(body))
+            self.headers['Content-Length'] = str(len(body))
         self._app_iter = app_iter
         for name, value in kw.items():
             if not hasattr(self.__class__, name):
@@ -575,7 +577,10 @@ class Response(object):
 
     def _charset__get(self):
         """
-        Get/set the charset (in the Content-Type)
+        Get/set the charset specified in Content-Type.
+
+        In the case JSON content where the charset param is not standards
+        compliant, we ignore this.
         """
         header = self.headers.get('Content-Type')
         if not header:
@@ -589,10 +594,12 @@ class Response(object):
         if charset is None:
             del self.charset
             return
-        header = self.headers.pop('Content-Type', None)
+        header = self.headers.get('Content-Type', None)
         if header is None:
             raise AttributeError("You cannot set the charset when no "
                                  "content-type is defined")
+        if _is_json(header):
+            return
         match = CHARSET_RE.search(header)
         if match:
             header = header[:match.start()] + header[match.end():]
@@ -657,7 +664,7 @@ class Response(object):
         """
         A dictionary of all the parameters in the content type.
 
-        (This is not a view, set to change, modifications of the dict would not
+        (This is not a view, set to change, modifications of the dict will not
         be applied otherwise)
         """
         params = self.headers.get('Content-Type', '')
@@ -677,10 +684,14 @@ class Response(object):
         for k, v in sorted(value_dict.items()):
             if not _OK_PARAM_RE.search(v):
                 v = '"%s"' % v.replace('"', '\\"')
-            params.append('; %s=%s' % (k, v))
+            # charset has constraints which we handle in its setter
+            if k != 'charset':
+                params.append('; %s=%s' % (k, v))
         ct = self.headers.pop('Content-Type', '').split(';', 1)[0]
         ct += ''.join(params)
         self.headers['Content-Type'] = ct
+        if 'charset' in value_dict:
+            self.charset = value_dict['charset']
 
     def _content_type_params__del(self):
         self.headers['Content-Type'] = self.headers.get(


### PR DESCRIPTION
Refactored the logic in Response.__init__ to handle default charset more consistently.

Added logic in the charset setter that ignores attempts to set it on JSON content types.

Removed explicit charset specification from exceptions since this is handled correctly for the text types within Response.

Fixed some affected tests, and added assertions for content types in exceptions.

Addresses https://github.com/Pylons/webob/issues/237 and https://github.com/Pylons/webob/issues/236