### PR TITLE
Support the SameSite field in Cookies

### DIFF
--- a/webob/response.py
+++ b/webob/response.py
@@ -702,7 +702,8 @@ class Response(object):
 
     def set_cookie(self, name=None, value='', max_age=None,
                    path='/', domain=None, secure=False, httponly=False,
-                   comment=None, expires=None, overwrite=False, key=None):
+                   comment=None, expires=None, overwrite=False, key=None,
+                   samesite=None):
         """
         Set (add) a cookie for the response.
 
@@ -753,6 +754,12 @@ class Response(object):
            in the cookie, if it's ``False``, the ``HttpOnly`` flag will not
            be sent in the cookie.
 
+        ``samesite``
+
+          A string representing the ``SameSite`` attribute of the cookie or
+          ``None``. If samesite is ``None`` no ``SameSite`` value will be sent
+          in the cookie. Should only be ``b"Strict"`` or ``b"Lax"``
+
         ``comment``
 
            A string representing the cookie ``Comment`` value, or ``None``.
@@ -800,7 +807,7 @@ class Response(object):
 
         cookie = make_cookie(name, value, max_age=max_age, path=path,
                 domain=domain, secure=secure, httponly=httponly,
-                comment=comment)
+                comment=comment, samesite=samesite)
 
         self.headerlist.append(('Set-Cookie', cookie))
 


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-west-first-party-cookies-07 and https://www.chromestatus.com/feature/4672634709082112 for more information.

This is shipping in Chrome since version 51, Opera since 39, positive support in Firefox.
