### PR TITLE
Adding explicit Sphinx reference to request and response documentation

### DIFF
--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -21,6 +21,8 @@ This is a somewhat different approach to reference documentation compared to
 the extracted documentation for the :py:mod:`~webob.request` and
 :py:mod:`~webob.response`.
 
+.. _request-reference:
+
 Request
 =======
 
@@ -541,6 +543,8 @@ in ``environ['webob.adhoc_attrs']`` (a dictionary).
     'blah blah blah'
     >>> req.environ['webob.adhoc_attrs']
     {'some_attr': 'blah blah blah'}
+
+.. _response-reference:
 
 Response
 ========


### PR DESCRIPTION
This way Pyramid document can correctly cross reference.