### PR TITLE
Strip whitespace from header value in fset

### DIFF
--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -155,8 +155,9 @@ def test_header_getter_fset_text_control_chars():
     from webob import Response
     resp = Response('aresp')
     desc = header_getter('AHEADER', '14.3')
+    desc.fset(resp, text_('pylons\n'))
     with pytest.raises(ValueError):
-        desc.fset(resp, text_('\n'))
+        desc.fset(resp, text_('pylons\npyramid'))
 
 def test_header_getter_fdel():
     from webob.descriptors import header_getter

--- a/webob/descriptors.py
+++ b/webob/descriptors.py
@@ -138,6 +138,8 @@ def header_getter(header, rfc_section):
     def fset(r, value):
         fdel(r)
         if value is not None:
+            value = value.strip()
+
             if '\n' in value or '\r' in value:
                 raise ValueError('Header value may not contain control characters')
 


### PR DESCRIPTION
When logging out via a template-rendered form (using pyramid.security.forget), it is sometimes possible that the form parameters have trailing whitespace, which triggers this exception on the server.

The proposed fix is to strip whitespace before storing the request header.

This fix is related to https://github.com/Pylons/webob/commit/c38021642a14616b5eda469e2312082f89b52243

@bertjwregeer 
