### PR TITLE
Fix: content_type/charset handling

### DIFF
--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -596,16 +596,11 @@ You can set any of these attributes, e.g.:
         ...
     TypeError: You cannot set Response.body to a unicode object (use Response.text)
     >>> res.text = u"test"
-    Traceback (most recent call last):
-        ...
-    AttributeError: You cannot access Response.text unless charset is set
-    >>> res.charset = 'utf8'
-    >>> res.text = u"test"
     >>> res.body
-    'test'
+    b'test'
 
 You can set any attribute with the constructor, like
-``Response(charset='utf8')``
+``Response(charset='UTF-8')``
 
 Headers
 -------

--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -596,6 +596,11 @@ You can set any of these attributes, e.g.:
         ...
     TypeError: You cannot set Response.body to a unicode object (use Response.text)
     >>> res.text = u"test"
+    Traceback (most recent call last):
+        ...
+    AttributeError: You cannot access Response.text unless charset is set
+    >>> res.charset = 'utf8'
+    >>> res.text = u"test"
     >>> res.body
     b'test'
 

--- a/docs/whatsnew-1.6.txt
+++ b/docs/whatsnew-1.6.txt
@@ -65,8 +65,17 @@ Bugfixes
   https://github.com/Pylons/webob/pull/183 for more information.
 
 - The application/json media type does not allow for a charset as discovery of
-  the encoding is done at the JSON layer. Upon initialization of a Response
-  WebOb will no longer add a charset if the content-type is set to JSON. See
-  https://github.com/Pylons/webob/pull/197 and
+  the encoding is done at the JSON layer, and it must always be UTF-{8,16,32}.
+  See the IANA spec at
+  https://www.iana.org/assignments/media-types/application/json, which notes
+
+    No "charset" parameter is defined for this registration.
+    Adding one really has no effect on compliant recipients.
+
+  RFC4627 describes the method for encoding discovery using the JSON content
+  itself. Upon initialization of a Response WebOb will no longer add a charset
+  if the content-type is set to JSON. See
+  https://github.com/Pylons/webob/pull/197,
+  https://github.com/Pylons/webob/issues/237 and
   https://github.com/Pylons/pyramid/issues/1611
 

--- a/docs/whatsnew-1.6.txt
+++ b/docs/whatsnew-1.6.txt
@@ -66,7 +66,7 @@ Bugfixes
 
 - The application/json media type does not allow for a charset as discovery of
   the encoding is done at the JSON layer, and it must always be UTF-{8,16,32}.
-  See the IANA spec at
+  See the IANA specification at
   https://www.iana.org/assignments/media-types/application/json, which notes
 
     No "charset" parameter is defined for this registration.

--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -139,6 +139,8 @@ def test_WSGIHTTPException_respects_application_json():
         title = 'Validation Failed'
         explanation = 'Validation of an attribute failed.'
     def start_response(status, headers, exc_info=None):
+        # check that json doesn't contain a charset
+        assert ('Content-Type', 'application/json') in headers
         pass
 
     exc = ValidationError(detail='Attribute "xyz" is invalid.')
@@ -216,6 +218,7 @@ def test_WSGIHTTPException_allows_custom_json_formatter():
 
 def test_WSGIHTTPException_generate_response():
     def start_response(status, headers, exc_info=None):
+        assert ('Content-Type', 'text/html; charset=UTF-8') in headers
         pass
     environ = {
        'wsgi.url_scheme': 'HTTP',

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3278,6 +3278,39 @@ class TestRequest_functional(object):
         assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
         assert res.body == b'Hi!'
 
+    def test_call_WSGI_app_204(self):
+        req = self._blankOne('/')
+        def wsgi_app(environ, start_response):
+            start_response('204 No Content', [])
+            return [b'']
+        assert req.call_application(wsgi_app) == ('204 No Content', [], [b''])
+
+        res = req.get_response(wsgi_app)
+        from webob.response import Response
+        assert isinstance(res, Response)
+        assert res.status == '204 No Content'
+        from webob.headers import ResponseHeaders
+        assert isinstance(res.headers, ResponseHeaders)
+        assert list(res.headers.items()) == []
+        assert res.body == b''
+
+    def test_call_WSGI_app_no_content_type(self):
+        req = self._blankOne('/')
+        def wsgi_app(environ, start_response):
+            start_response('200 OK', [])
+            return [b'']
+        assert req.call_application(wsgi_app) == ('200 OK', [], [b''])
+
+        res = req.get_response(wsgi_app)
+        from webob.response import Response
+        assert isinstance(res, Response)
+        assert res.status == '200 OK'
+        assert res.content_type is None
+        from webob.headers import ResponseHeaders
+        assert isinstance(res.headers, ResponseHeaders)
+        assert list(res.headers.items()) == []
+        assert res.body == b''
+
     def test_get_response_catch_exc_info_true(self):
         req = self._blankOne('/')
         def wsgi_app(environ, start_response):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3265,9 +3265,9 @@ class TestRequest_functional(object):
     def test_call_WSGI_app(self):
         req = self._blankOne('/')
         def wsgi_app(environ, start_response):
-            start_response('200 OK', [('Content-type', 'text/plain')])
+            start_response('200 OK', [('Content-Type', 'text/plain')])
             return [b'Hi!']
-        assert req.call_application(wsgi_app) == ('200 OK', [('Content-type', 'text/plain')], [b'Hi!'])
+        assert req.call_application(wsgi_app) == ('200 OK', [('Content-Type', 'text/plain')], [b'Hi!'])
 
         res = req.get_response(wsgi_app)
         from webob.response import Response
@@ -3275,13 +3275,13 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-type', 'text/plain')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
         assert res.body == b'Hi!'
 
     def test_get_response_catch_exc_info_true(self):
         req = self._blankOne('/')
         def wsgi_app(environ, start_response):
-            start_response('200 OK', [('Content-type', 'text/plain')])
+            start_response('200 OK', [('Content-Type', 'text/plain')])
             return [b'Hi!']
         res = req.get_response(wsgi_app, catch_exc_info=True)
         from webob.response import Response
@@ -3289,7 +3289,7 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-type', 'text/plain')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
         assert res.body == b'Hi!'
 
     def equal_req(self, req, inp):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -141,16 +141,6 @@ def test_init_keeps_specified_charset_when_json():
     expected = content_type
     assert Response(content_type=content_type).headers['content-type'] == expected
 
-def test_set_charset_fails_when_json():
-    content_type = 'application/json'
-    expected = content_type
-    res = Response(content_type=content_type)
-    res.charset = 'utf-8'
-    assert res.headers['content-type'] == expected
-    res.content_type_params = {'charset': 'utf-8'}
-    assert res.headers['content-type'] == expected
-
-
 def test_cookies():
     res = Response()
     # test unicode value

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -143,6 +143,9 @@ def test_init_keeps_specified_charset_when_json():
     expected = content_type
     assert Response(content_type=content_type).headers['content-type'] == expected
 
+def test_init_doesnt_add_default_content_type_with_bodyless_status():
+    assert Response(status='204 No Content').content_type is None
+
 def test_cookies():
     res = Response()
     # test unicode value

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -36,9 +36,9 @@ def test_response():
     res.body = b'Not OK'
     assert b''.join(res.app_iter) == b'Not OK'
     res.charset = 'iso8859-1'
-    assert res.headers['content-type'] == 'text/html; charset=iso8859-1'
+    assert 'text/html; charset=iso8859-1' == res.headers['content-type']
     res.content_type = 'text/xml'
-    assert res.headers['content-type'] == 'text/xml; charset=iso8859-1'
+    assert 'text/xml; charset=iso8859-1' == res.headers['content-type']
     res.headers = {'content-type': 'text/html'}
     assert res.headers['content-type'] == 'text/html'
     assert res.headerlist == [('content-type', 'text/html')]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -66,6 +66,9 @@ def test_response():
                  body=text_(b"unicode body"))
     with pytest.raises(TypeError):
         Response(wrong_key='dummy')
+    with pytest.raises(TypeError):
+        resp = Response()
+        resp.body = text_(b"unicode body")
 
 def test_set_response_status_binary():
     req = BaseRequest.blank('/')
@@ -692,7 +695,7 @@ def test_text_get_decode():
     res = Response()
     res.charset = 'utf-8'
     res.body = b'La Pe\xc3\xb1a'
-    assert res.text, text_(b'La Pe\xc3\xb1a' == 'utf-8')
+    assert res.text, text_(b'La Pe\xc3\xb1a')
 
 def test_text_set_no_charset():
     res = Response()
@@ -752,7 +755,7 @@ def test_charset_set_no_content_type_header():
     res = Response()
     res.headers.pop('Content-Type', None)
     with pytest.raises(AttributeError):
-        res.__setattr__('charset', 'utf-8')
+        res.charset = 'utf-8'
 
 def test_charset_del_no_content_type_header():
     res = Response()
@@ -779,6 +782,11 @@ def test_content_type_params_set_ok_param_quoting():
     res = Response()
     res.content_type_params = {'a': ''}
     assert res.headers['Content-Type'] == 'text/html; a=""'
+
+def test_charset_delete():
+    res = Response()
+    del res.charset
+    assert res.charset is None
 
 def test_set_cookie_overwrite():
     res = Response()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -39,6 +39,8 @@ def test_response():
     assert 'text/html; charset=iso8859-1' == res.headers['content-type']
     res.content_type = 'text/xml'
     assert 'text/xml; charset=iso8859-1' == res.headers['content-type']
+    res.content_type = 'text/xml; charset=UTF-8'
+    assert 'text/xml; charset=UTF-8' == res.headers['content-type']
     res.headers = {'content-type': 'text/html'}
     assert res.headers['content-type'] == 'text/html'
     assert res.headerlist == [('content-type', 'text/html')]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -139,7 +139,7 @@ def test_init_no_charset_when_json():
     assert Response(content_type=content_type).headers['content-type'] == expected
 
 def test_init_keeps_specified_charset_when_json():
-    content_type = 'application/json;charset=ISO-8859-1'
+    content_type = 'application/json; charset=ISO-8859-1'
     expected = content_type
     assert Response(content_type=content_type).headers['content-type'] == expected
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -60,6 +60,7 @@ def test_response():
     del req.environ
     with pytest.raises(TypeError):
         Response(charset=None,
+                 content_type='image/jpeg',
                  body=text_(b"unicode body"))
     with pytest.raises(TypeError):
         Response(wrong_key='dummy')
@@ -139,6 +140,15 @@ def test_init_keeps_specified_charset_when_json():
     content_type = 'application/json;charset=ISO-8859-1'
     expected = content_type
     assert Response(content_type=content_type).headers['content-type'] == expected
+
+def test_set_charset_fails_when_json():
+    content_type = 'application/json'
+    expected = content_type
+    res = Response(content_type=content_type)
+    res.charset = 'utf-8'
+    assert res.headers['content-type'] == expected
+    res.content_type_params = {'charset': 'utf-8'}
+    assert res.headers['content-type'] == expected
 
 
 def test_cookies():

--- a/webob/exc.py
+++ b/webob/exc.py
@@ -338,14 +338,10 @@ ${body}''')
         else:
             content_type = 'text/plain'
             body = self.plain_body(environ)
-        extra_kw = {}
-        if isinstance(body, text_type):
-            extra_kw.update(charset='utf-8')
         resp = Response(body,
                         status=self.status,
                         headerlist=headerlist,
                         content_type=content_type,
-                        **extra_kw
                         )
         resp.content_type = content_type
         return resp(environ, start_response)

--- a/webob/response.py
+++ b/webob/response.py
@@ -112,7 +112,7 @@ class Response(object):
         else:
             self._headerlist = headerlist
         content_type = content_type or self.headers.get('Content-Type') or \
-                self.default_content_type
+            self.default_content_type
         if 'Content-Type' not in self.headers:
             self.headers['Content-Type'] = content_type
         charset = kw.get('charset')
@@ -153,7 +153,6 @@ class Response(object):
                 raise TypeError(
                     "Unexpected keyword: %s=%r" % (name, value))
             setattr(self, name, value)
-
 
     @classmethod
     def from_file(cls, fp):
@@ -220,7 +219,6 @@ class Response(object):
             headerlist=self._headerlist[:],
             app_iter=app_iter,
             conditional_response=self.conditional_response)
-
 
     #
     # __repr__, __str__
@@ -290,8 +288,7 @@ class Response(object):
             self._status = '%d %s' % (code, status_generic_reasons[code // 100])
 
     status_code = status_int = property(_status_code__get, _status_code__set,
-                           doc=_status_code__get.__doc__)
-
+                                        doc=_status_code__get.__doc__)
 
     #
     # headerslist, headers
@@ -332,7 +329,6 @@ class Response(object):
         self._headers = None
 
     headers = property(_headers__get, _headers__set, doc=_headers__get.__doc__)
-
 
     #
     # body
@@ -400,7 +396,8 @@ class Response(object):
         return json.loads(self.body.decode(self.charset or 'UTF-8'))
 
     def _json_body__set(self, value):
-        self.body = json.dumps(value, separators=(',', ':')).encode(self.charset or 'UTF-8')
+        self.body = json.dumps(value, separators=(',', ':')).encode(
+            self.charset or 'UTF-8')
 
     def _json_body__del(self):
         del self.body
@@ -424,7 +421,6 @@ class Response(object):
         return True
 
     has_body = property(_has_body__get)
-
 
     #
     # text, unicode_body, ubody
@@ -457,7 +453,7 @@ class Response(object):
     text = property(_text__get, _text__set, _text__del, doc=_text__get.__doc__)
 
     unicode_body = ubody = property(_text__get, _text__set, _text__del,
-        "Deprecated alias for .text")
+                                    "Deprecated alias for .text")
 
     #
     # body_file, write(text)
@@ -502,8 +498,6 @@ class Response(object):
         if self.content_length is not None:
             self.content_length += len(text)
 
-
-
     #
     # app_iter
     #
@@ -530,8 +524,6 @@ class Response(object):
 
     app_iter = property(_app_iter__get, _app_iter__set, _app_iter__del,
                         doc=_app_iter__get.__doc__)
-
-
 
     #
     # headers attrs
@@ -562,7 +554,8 @@ class Response(object):
     last_modified = date_header('Last-Modified', '14.29')
 
     _etag_raw = header_getter('ETag', '14.19')
-    etag = converter(_etag_raw,
+    etag = converter(
+        _etag_raw,
         parse_etag_response, serialize_etag_response,
         'Entity tag'
     )
@@ -587,7 +580,6 @@ class Response(object):
         header_getter('WWW-Authenticate', '14.47'),
         parse_auth, serialize_auth,
     )
-
 
     #
     # charset
@@ -637,7 +629,6 @@ class Response(object):
     charset = property(_charset__get, _charset__set, _charset__del,
                        doc=_charset__get.__doc__)
 
-
     #
     # content_type
     #
@@ -672,7 +663,6 @@ class Response(object):
 
     content_type = property(_content_type__get, _content_type__set,
                             _content_type__del, doc=_content_type__get.__doc__)
-
 
     #
     # content_type_params
@@ -721,9 +711,6 @@ class Response(object):
         _content_type_params__del,
         _content_type_params__get.__doc__
     )
-
-
-
 
     #
     # set_cookie, unset_cookie, delete_cookie, merge_cookies
@@ -827,9 +814,10 @@ class Response(object):
 
         value = bytes_(value, 'utf-8')
 
-        cookie = make_cookie(name, value, max_age=max_age, path=path,
-                domain=domain, secure=secure, httponly=httponly,
-                comment=comment)
+        cookie = make_cookie(
+            name, value, max_age=max_age, path=path,
+            domain=domain, secure=secure, httponly=httponly,
+            comment=comment)
 
         self.headerlist.append(('Set-Cookie', cookie))
 
@@ -864,7 +852,6 @@ class Response(object):
         elif strict:
             raise KeyError("No cookie has been set with the name %r" % name)
 
-
     def merge_cookies(self, resp):
         """Merge the cookies that were set on this response with the
         given `resp` object (which can be any WSGI application).
@@ -883,11 +870,10 @@ class Response(object):
                          h[0].lower() == 'set-cookie']
             def repl_app(environ, start_response):
                 def repl_start_response(status, headers, exc_info=None):
-                    return start_response(status, headers+c_headers,
+                    return start_response(status, headers + c_headers,
                                           exc_info=exc_info)
                 return resp(environ, repl_start_response)
             return repl_app
-
 
     #
     # cache_control
@@ -944,7 +930,6 @@ class Response(object):
         _cache_control__get, _cache_control__set,
         _cache_control__del, doc=_cache_control__get.__doc__)
 
-
     #
     # cache_expires
     #
@@ -987,8 +972,6 @@ class Response(object):
 
     cache_expires = property(lambda self: self._cache_expires, _cache_expires)
 
-
-
     #
     # encode_content, decode_content, md5_etag
     #
@@ -999,7 +982,7 @@ class Response(object):
         identity are supported).
         """
         assert encoding in ('identity', 'gzip'), \
-               "Unknown encoding: %r" % encoding
+            "Unknown encoding: %r" % encoding
         if encoding == 'identity':
             self.decode_content()
             return
@@ -1049,8 +1032,6 @@ class Response(object):
         self.etag = md5_digest.strip('=')
         if set_content_md5:
             self.content_md5 = md5_digest
-
-
 
     #
     # __call__, conditional_response_app
@@ -1105,11 +1086,12 @@ class Response(object):
             if status304:
                 start_response('304 Not Modified', filter_headers(headerlist))
                 return EmptyResponse(self._app_iter)
-        if (req.range and self in req.if_range
-            and self.content_range is None
-            and method in ('HEAD', 'GET')
-            and self.status_code == 200
-            and self.content_length is not None
+        if (
+            req.range and self in req.if_range and
+            self.content_range is None and
+            method in ('HEAD', 'GET') and
+            self.status_code == 200 and
+            self.content_length is not None
         ):
             content_range = req.range.content_range(self.content_length)
             if content_range is None:
@@ -1144,7 +1126,7 @@ class Response(object):
                     return app_iter
 
         start_response(self.status, headerlist)
-        if method  == 'HEAD':
+        if method == 'HEAD':
             return EmptyResponse(self._app_iter)
         return self._app_iter
 
@@ -1163,7 +1145,7 @@ def filter_headers(hlist, remove_headers=('content-length', 'content-type')):
     return [h for h in hlist if (h[0].lower() not in remove_headers)]
 
 
-def iter_file(file, block_size=1<<18): # 256Kb
+def iter_file(file, block_size=1 << 18): # 256Kb
     while True:
         data = file.read(block_size)
         if not data:
@@ -1196,8 +1178,6 @@ class ResponseBodyFile(object):
     def flush(self):
         pass
 
-
-
 class AppIterRange(object):
     """
     Wraps an app_iter, returning just a range of bytes
@@ -1224,14 +1204,13 @@ class AppIterRange(object):
             elif self._pos == start:
                 return b''
             else:
-                chunk = chunk[start-self._pos:]
+                chunk = chunk[start - self._pos:]
                 if stop is not None and self._pos > stop:
-                    chunk = chunk[:stop-self._pos]
+                    chunk = chunk[:stop - self._pos]
                     assert len(chunk) == stop - start
                 return chunk
         else:
             raise StopIteration()
-
 
     def next(self):
         if self._pos < self.start:
@@ -1247,7 +1226,7 @@ class AppIterRange(object):
         if stop is None or self._pos <= stop:
             return chunk
         else:
-            return chunk[:stop-self._pos]
+            return chunk[:stop - self._pos]
 
     __next__ = next # py3
 
@@ -1278,20 +1257,26 @@ class EmptyResponse(object):
     __next__ = next # py3
 
 def _is_json(content_type):
-    return (content_type.startswith('application/json')
-            or (content_type.startswith('application/')
-                and content_type.endswith('+json')))
+    return (
+        content_type.startswith('application/json') or (
+            content_type.startswith('application/') and
+            content_type.endswith('+json')
+        )
+    )
 
 def _is_xml(content_type):
-    return (content_type.startswith('application/xml')
-            or (content_type.startswith('application/')
-                and content_type.endswith('+xml')))
+    return (
+        content_type.startswith('application/xml') or (
+            content_type.startswith('application/') and
+            content_type.endswith('+xml')
+        )
+    )
 
 def _request_uri(environ):
     """Like wsgiref.url.request_uri, except eliminates :80 ports
 
     Return the full request URI"""
-    url = environ['wsgi.url_scheme']+'://'
+    url = environ['wsgi.url_scheme'] + '://'
 
     if environ.get('HTTP_HOST'):
         url += environ['HTTP_HOST']
@@ -1311,7 +1296,7 @@ def _request_uri(environ):
 
     url += url_quote(script_name)
     qpath_info = url_quote(path_info)
-    if not 'SCRIPT_NAME' in environ:
+    if 'SCRIPT_NAME' not in environ:
         url += qpath_info[1:]
     else:
         url += qpath_info

--- a/webob/response.py
+++ b/webob/response.py
@@ -68,6 +68,8 @@ _OK_PARAM_RE = re.compile(r'^[a-z0-9_.-]+$', re.I)
 
 _gzip_header = b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xff'
 
+_marker = object()
+
 class Response(object):
     """
         Represents a WSGI response
@@ -85,7 +87,7 @@ class Response(object):
     #
 
     def __init__(self, body=None, status=None, headerlist=None, app_iter=None,
-                 content_type=None, conditional_response=None,
+                 content_type=None, conditional_response=None, charset=_marker,
                  **kw):
 
         body_encoding = None
@@ -134,10 +136,8 @@ class Response(object):
             self.headers['Content-Type'] = content_type
 
         # Set up the charset
-        charset = kw.get('charset')
-
         if self.content_type:
-            if charset:
+            if charset is not _marker:
                 self.charset = charset
             elif not self.charset and self.default_charset:
                 if _content_type_has_charset(self.content_type):

--- a/webob/response.py
+++ b/webob/response.py
@@ -804,6 +804,8 @@ class Response(object):
                         del params['charset']
 
                 self.content_type_params = params
+            else:
+                self.headers['Content-Type'] = value
         else:
             self.headers['Content-Type'] = value
 

--- a/webob/response.py
+++ b/webob/response.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     import json
 
+import warnings
+
 from webob.byterange import ContentRange
 
 from webob.cachecontrol import (
@@ -784,12 +786,12 @@ class Response(object):
 
                 if 'charset' in params:
                     if not _content_type_has_charset(value):
-                        warn_deprecation(
+                        warnings.warn(
                             'Explicitly removing charset as new content_type '
                             'does not allow charset as a parameter. If you are '
                             'expecting a charset to be set, please add it back '
                             'explicitly after setting the content_type.',
-                            1.9, 1)
+                            RuntimeWarning)
                         del params['charset']
 
                 self.content_type_params = params

--- a/webob/response.py
+++ b/webob/response.py
@@ -408,11 +408,10 @@ class Response(object):
     def _json_body__get(self):
         """Access the body of the response as JSON"""
         # Note: UTF-8 is a content-type specific default for JSON:
-        return json.loads(self.body.decode(self.charset or 'UTF-8'))
+        return json.loads(self.body.decode('UTF-8'))
 
     def _json_body__set(self, value):
-        self.body = json.dumps(value, separators=(',', ':')).encode(
-            self.charset or 'UTF-8')
+        self.body = json.dumps(value, separators=(',', ':')).encode('UTF-8')
 
     def _json_body__del(self):
         del self.body

--- a/webob/response.py
+++ b/webob/response.py
@@ -210,13 +210,29 @@ class Response(object):
         # Set up the content_type
         content_type = content_type or self.default_content_type
 
+        # We only set the content_type to the one passed to the constructor or
+        # the default content type if there is none that exists AND there was
+        # no headerlist passed. If a headerlist was provided then most likely
+        # the ommission of the Content-Type is on purpose and we shouldn't try
+        # to be smart about it.
+        #
+        # Also allow creation of a empty Response with just the status set to a
+        # Response with empty body, such as Response(status='204 No Content')
+        # without the default content_type being set
+
         if (
-            'Content-Type' not in self.headers and
+            self.content_type is None and
+            headerlist is None and
             _code_has_body(self.status_code)
         ):
             self.content_type = content_type
 
         # Set up the charset
+        #
+        # In contrast with the above, if a charset is not set but there is a
+        # content_type we will set the default charset if the content_type
+        # allows for a charset.
+
         if self.content_type:
             if charset is not _marker:
                 self.charset = charset

--- a/webob/response.py
+++ b/webob/response.py
@@ -89,7 +89,8 @@ class Response(object):
         converted to a proper status that also includes the status text. Any
         existing status text will be kept, non-standard values are allowed.
 
-        ``headerlist`` is a list of HTTP headers for the response.
+        ``headerlist`` is a list of HTTP headers for the response as tuples of
+        HTTP header name, value pairs.
 
         ``content_type`` sets the `Content-Type` header. If the ``headerlist``
         already contains a `Content-Type` it will take precedence. If no

--- a/webob/response.py
+++ b/webob/response.py
@@ -1271,20 +1271,23 @@ class EmptyResponse(object):
 
     __next__ = next # py3
 
-def _is_json(content_type):
+def _is_xml(content_type):
     return (
-        content_type.startswith('application/json') or (
+        content_type.startswith('application/xml') or
+        (
             content_type.startswith('application/') and
-            content_type.endswith('+json')
+            content_type.endswith('+xml')
+        ) or
+        (
+            content_type.startswith('image/') and
+            content_type.endswith('+xml')
         )
     )
 
-def _is_xml(content_type):
+def _content_type_has_charset(content_type):
     return (
-        content_type.startswith('application/xml') or (
-            content_type.startswith('application/') and
-            content_type.endswith('+xml')
-        )
+        content_type.startswith('text/') or
+        _is_xml(content_type)
     )
 
 def _request_uri(environ):

--- a/webob/response.py
+++ b/webob/response.py
@@ -833,14 +833,10 @@ class Response(object):
         for k, v in sorted(value_dict.items()):
             if not _OK_PARAM_RE.search(v):
                 v = '"%s"' % v.replace('"', '\\"')
-            # charset has constraints which we handle in its setter
-            if k != 'charset':
-                params.append('; %s=%s' % (k, v))
+            params.append('; %s=%s' % (k, v))
         ct = self.headers.pop('Content-Type', '').split(';', 1)[0]
         ct += ''.join(params)
         self.headers['Content-Type'] = ct
-        if 'charset' in value_dict:
-            self.charset = value_dict['charset']
 
     def _content_type_params__del(self):
         self.headers['Content-Type'] = self.headers.get(

--- a/webob/response.py
+++ b/webob/response.py
@@ -604,8 +604,8 @@ class Response(object):
         """
         Get/set the charset specified in Content-Type.
 
-        In the case JSON content where the charset param is not standards
-        compliant, we ignore this.
+        There is no checking to validate that a ``content_type`` actually allows
+        for a charset parameter.
         """
         header = self.headers.get('Content-Type')
         if not header:
@@ -623,8 +623,6 @@ class Response(object):
         if header is None:
             raise AttributeError("You cannot set the charset when no "
                                  "content-type is defined")
-        if _is_json(header):
-            return
         match = CHARSET_RE.search(header)
         if match:
             header = header[:match.start()] + header[match.end():]

--- a/webob/response.py
+++ b/webob/response.py
@@ -208,15 +208,13 @@ class Response(object):
             self._headerlist = headerlist
 
         # Set up the content_type
-        content_type = content_type or self.headers.get('Content-Type') or \
-            self.default_content_type
+        content_type = content_type or self.default_content_type
 
         if (
             'Content-Type' not in self.headers and
-            content_type and
             _code_has_body(self.status_code)
         ):
-            self.headers['Content-Type'] = content_type
+            self.content_type = content_type
 
         # Set up the charset
         if self.content_type:

--- a/webob/response.py
+++ b/webob/response.py
@@ -77,27 +77,32 @@ class Response(object):
         Represents a WSGI response.
 
         If no arguments are passed, creates a :py:class:`~Response` that uses a
-        variety of defaults. Defaults may be changed by sub-classing the
+        variety of defaults. The defaults may be changed by sub-classing the
         :py:class:`~Response`. See the :ref:`sub-classing notes
         <response_subclassing_notes>`.
 
-        :cvar ~Response.body: ``body`` may be a :py:class:`bytes` or ``text_type``. If
-            ``body`` is a ``text_type``, then it will be encoded using either
-            ``charset`` when provided or ``default_encoding`` when ``charset``
-            is not provided. This argument is mutually  exclusive with
-            ``app_iter``.
+        :cvar ~Response.body: If ``body`` is a ``text_type``, then it will be
+            encoded using either ``charset`` when provided or
+            ``default_encoding`` when ``charset`` is not provided. This
+            argument is mutually  exclusive with ``app_iter``.
 
         :vartype ~Response.body: bytes or text_type
 
-        :cvar status: Either an :py:class:`int` or a string that is an integer
-            followed by the status text. If it is an integer, it will be
-            converted to a proper status that also includes the status text.
-            Any existing status text will be kept. Non-standard values are
-            allowed.
+        :cvar ~Response.status: Either an :py:class:`int` or a string that is
+            an integer followed by the status text. If it is an integer, it
+            will be converted to a proper status that also includes the status
+            text.  Any existing status text will be kept. Non-standard values
+            are allowed.
 
-        :vartype status: int or str
+        :vartype ~Response.status: int or str
 
-        :cvar list headerlist: A list of HTTP headers for the response.
+        :cvar list ~Response.headerlist: A list of HTTP headers for the response.
+
+        :cvar ~Response.app_iter: An iterator that is used as the body of the
+            response. Should conform to the WSGI requirements and should
+            provide bytes. This argument is mutually exclusive with ``body``.
+
+        :vartype ~Response.app_iter: iterable
 
         :cvar ~Response.content_type: Sets the ``Content-Type`` header. If the
             ``headerlist`` already contains a ``Content-Type``, then it will
@@ -112,12 +117,16 @@ class Response(object):
             response headers. See :py:meth:`~Response.conditional_response_app`
             for more information.
 
-        :cvar charset: Adds a ``charset`` ``Content-Type`` parameter. If no
+        :vartype conditional_response: bool
+
+        :cvar ~Response.charset: Adds a ``charset`` ``Content-Type`` parameter. If no
             ``charset`` is provided and the ``Content-Type`` is text, then the
             ``default_charset`` will automatically be added.  Currently the
             only ``Content-Type``'s that allow for a ``charset`` are defined to
             be ``text/*``, ``application/xml``, and ``*/*+xml``. Any other
             ``Content-Type``'s will not have a ``charset`` added.
+
+        :vartype ~Response.charset: str or None
 
         All other response attributes may be set on the response by providing
         them as keyword arguments. A :py:exc:`TypeError` will be raised for any

--- a/webob/response.py
+++ b/webob/response.py
@@ -214,7 +214,6 @@ class Response(object):
         # and this to make sure app_iter instances are different
         self._app_iter = list(app_iter)
         return self.__class__(
-            content_type=False,
             status=self._status,
             headerlist=self._headerlist[:],
             app_iter=app_iter,

--- a/webob/response.py
+++ b/webob/response.py
@@ -126,17 +126,21 @@ class Response(object):
         content_type = content_type or self.headers.get('Content-Type') or \
             self.default_content_type
 
-        if 'Content-Type' not in self.headers and content_type:
+        if (
+            'Content-Type' not in self.headers and
+            content_type and
+            _code_has_body(self.status_code)
+        ):
             self.headers['Content-Type'] = content_type
 
         # Set up the charset
         charset = kw.get('charset')
 
-        if content_type:
+        if self.content_type:
             if charset:
                 self.charset = charset
             elif not self.charset and self.default_charset:
-                if _content_type_has_charset(content_type):
+                if _content_type_has_charset(self.content_type):
                     self.charset = self.default_charset
 
             body_encoding = self.charset or body_encoding
@@ -1305,6 +1309,13 @@ class EmptyResponse(object):
         raise StopIteration()
 
     __next__ = next # py3
+
+def _code_has_body(status_code):
+    return (
+        (not (100 <= status_code < 199)) and
+        (status_code != 204) and
+        (status_code != 304)
+    )
 
 def _is_xml(content_type):
     return (

--- a/webob/response.py
+++ b/webob/response.py
@@ -616,7 +616,7 @@ class Response(object):
 
     def _charset__set(self, charset):
         if charset is None:
-            del self.charset
+            self._charset__del()
             return
         header = self.headers.get('Content-Type', None)
         if header is None:
@@ -698,8 +698,9 @@ class Response(object):
 
     def _content_type_params__set(self, value_dict):
         if not value_dict:
-            del self.content_type_params
+            self._content_type_params__del()
             return
+
         params = []
         for k, v in sorted(value_dict.items()):
             if not _OK_PARAM_RE.search(v):

--- a/webob/response.py
+++ b/webob/response.py
@@ -268,7 +268,10 @@ class Response(object):
 
         # Attempt to get the status code itself, if this fails we should fail
         try:
-            status_code = int(value.split()[0])
+            # We don't need this value anywhere, we just want to validate it's
+            # an integer. So we are using the side-effect of int() raises a
+            # ValueError as a test
+            int(value.split()[0])
         except ValueError:
             raise ValueError('Invalid status code, integer required.')
         self._status = value

--- a/webob/response.py
+++ b/webob/response.py
@@ -74,40 +74,48 @@ class Response(object):
     """
         Represents a WSGI response.
 
-        If no arguments are passed creates a :py:class:`~Response` that uses a
+        If no arguments are passed, creates a :py:class:`~Response` that uses a
         variety of defaults. Defaults may be changed by sub-classing the
-        :py:class:`~Response`, see the :ref:`sub-classing notes
+        :py:class:`~Response`. See the :ref:`sub-classing notes
         <response_subclassing_notes>`.
 
-        The ``body`` may be a :py:class:`bytes` or a ``text_type``. If it is a
-        ``text_type`` it will be encoded using the ``charset`` or if there is
-        no ``charset`` using ``default_encoding``. This argument is mutually
-        exclusive with ``app_iter``.
+        :cvar ~Response.body: ``body`` may be a :py:class:`bytes` or ``text_type``. If
+            ``body`` is a ``text_type``, then it will be encoded using either
+            ``charset`` when provided or ``default_encoding`` when ``charset``
+            is not provided. This argument is mutually  exclusive with
+            ``app_iter``.
 
-        The ``status`` is a either an :py:class:`int` or a string that is an
-        integer followed by the status text. If it is an integer, it will be
-        converted to a proper status that also includes the status text. Any
-        existing status text will be kept, non-standard values are allowed.
+        :vartype ~Response.body: bytes or text_type
 
-        ``headerlist`` is a list of HTTP headers for the response as tuples of
-        HTTP header name, value pairs.
+        :cvar status: Either an :py:class:`int` or a string that is an integer
+            followed by the status text. If it is an integer, it will be
+            converted to a proper status that also includes the status text.
+            Any existing status text will be kept. Non-standard values are
+            allowed.
 
-        ``content_type`` sets the `Content-Type` header. If the ``headerlist``
-        already contains a `Content-Type` it will take precedence. If no
-        ``Content-Type`` is set in either the ``headerlist`` the
-        ``default_content_type`` value will be used instead.
+        :vartype status: int or str
 
-        ``conditional_response`` is used to change the behaviour of the
-        :py:class:`~Response` to check the original request for conditional
-        response headers. See :py:meth:`~Response.conditional_response_app` for
-        more information.
+        :cvar list headerlist: A list of HTTP headers for the response.
 
-        The ``charset`` adds a ``charset`` ``Content-Type`` parameter. If no
-        ``charset`` is provided, and the ``Content-Type`` is text, the
-        ``default_charset`` will automatically be added.  Currently the only
-        ``Content-Type``'s that allow for a ``charset`` are defined to be:
-        ``text/*``, ``application/xml``, and ``*/*+xml``. Any other
-        ``Content-Type``'s will not have a ``charset`` added.
+        :cvar ~Response.content_type: Sets the ``Content-Type`` header. If the
+            ``headerlist`` already contains a ``Content-Type``, then it will
+            take precedence. If no ``Content-Type`` is set in the
+            ``headerlist``, then the ``default_content_type`` value will be
+            used instead.
+
+        :vartype ~Response.content_type: str or None
+
+        :cvar conditional_response: Used to change the behavior of the
+            :py:class:`~Response` to check the original request for conditional
+            response headers. See :py:meth:`~Response.conditional_response_app`
+            for more information.
+
+        :cvar charset: Adds a ``charset`` ``Content-Type`` parameter. If no
+            ``charset`` is provided and the ``Content-Type`` is text, then the
+            ``default_charset`` will automatically be added.  Currently the
+            only ``Content-Type``'s that allow for a ``charset`` are defined to
+            be ``text/*``, ``application/xml``, and ``*/*+xml``. Any other
+            ``Content-Type``'s will not have a ``charset`` added.
 
         All other response attributes may be set on the response by providing
         them as keyword arguments. A :py:exc:`TypeError` will be raised for any
@@ -117,25 +125,25 @@ class Response(object):
 
         **Sub-classing notes:**
 
-        The ``default_content_type`` is used as the default for the
-        ``Content-Type`` header that is returned on the response. It is
-        ``text/html``.
+        * The ``default_content_type`` is used as the default for the
+          ``Content-Type`` header that is returned on the response. It is
+          ``text/html``.
 
-        The ``default_charset`` is used as the default character set to return
-        on the ``Content-Type`` header, if the ``Content-Type`` allows for a
-        ``charset`` paramater. Currently the only ``Content-Type``'s that allow
-        for a ``charset`` are defined to be: ``text/*``, ``application/xml``,
-        and ``*/*+xml``. Any other ``Content-Type``'s will not have a
-        ``charset`` added.
+        * The ``default_charset`` is used as the default character set to
+          return on the ``Content-Type`` header, if the ``Content-Type`` allows
+          for a ``charset`` parameter. Currently the only ``Content-Type``'s
+          that allow for a ``charset`` are defined to be: ``text/*``,
+          ``application/xml``, and ``*/*+xml``. Any other ``Content-Type``'s
+          will not have a ``charset`` added.
 
-        The ``unicode_errors`` is set to ``strict``, and access on a
-        :py:attr:`~Response.text` will raise an error if it fails to decode the
-        :py:attr:`~Response.body`.
+        * The ``unicode_errors`` is set to ``strict``, and access on a
+          :py:attr:`~Response.text` will raise an error if it fails to decode the
+          :py:attr:`~Response.body`.
 
-        ``default_conditional_response`` is set to False. This flag may be set
-        to True so that all ``Response`` objects will attempt to check the
-        original request for conditional response headers. See
-        :py:meth:`~Response.conditional_response_app` for more information.
+        * ``default_conditional_response`` is set to False. This flag may be
+          set to True so that all ``Response`` objects will attempt to check
+          the original request for conditional response headers. See
+          :py:meth:`~Response.conditional_response_app` for more information.
     """
 
     default_content_type = 'text/html'

--- a/webob/response.py
+++ b/webob/response.py
@@ -256,7 +256,7 @@ class Response(object):
         else:
             self.status_code = code
             return
-        if PY3: # pragma: no cover
+        if PY3:
             if isinstance(value, bytes):
                 value = value.decode('ascii')
         elif isinstance(value, text_type):
@@ -362,7 +362,7 @@ class Response(object):
         if len(body) == 0:
             # if body-length is zero, we assume it's a HEAD response and
             # leave content_length alone
-            pass # pragma: no cover (no idea why necessary, it's hit)
+            pass
         elif self.content_length is None:
             self.content_length = len(body)
         elif self.content_length != len(body):

--- a/webob/response.py
+++ b/webob/response.py
@@ -234,7 +234,7 @@ class Response(object):
         # allows for a charset.
 
         if self.content_type:
-            if charset is not _marker:
+            if not self.charset and charset is not _marker:
                 self.charset = charset
             elif not self.charset and self.default_charset:
                 if _content_type_has_charset(self.content_type):

--- a/webob/response.py
+++ b/webob/response.py
@@ -695,6 +695,12 @@ class Response(object):
 
                 if 'charset' in params:
                     if not _content_type_has_charset(value):
+                        warn_deprecation(
+                            'Explicitly removing charset as new content_type '
+                            'does not allow charset as a parameter. If you are '
+                            'expecting a charset to be set, please add it back '
+                            'explicitly after setting the content_type.',
+                            1.9, 1)
                         del params['charset']
 
                 self.content_type_params = params

--- a/webob/response.py
+++ b/webob/response.py
@@ -74,8 +74,8 @@ class Response(object):
     """
 
     default_content_type = 'text/html'
-    default_charset = 'UTF-8' # TODO: deprecate
-    unicode_errors = 'strict' # TODO: deprecate (why would response body have errors?)
+    default_charset = 'UTF-8'
+    unicode_errors = 'strict'
     default_conditional_response = False
     request = None
     environ = None

--- a/webob/response.py
+++ b/webob/response.py
@@ -113,7 +113,7 @@ class Response(object):
             self._headerlist = headerlist
         content_type = content_type or self.headers.get('Content-Type') or \
             self.default_content_type
-        if 'Content-Type' not in self.headers:
+        if 'Content-Type' not in self.headers and content_type:
             self.headers['Content-Type'] = content_type
         charset = kw.get('charset')
         if content_type:

--- a/webob/response.py
+++ b/webob/response.py
@@ -79,6 +79,11 @@ class Response(object):
     default_charset = 'UTF-8'
     unicode_errors = 'strict'
     default_conditional_response = False
+
+    # These two are only around so that when people pass them into the
+    # constructor they correctly get saved and set, however they are not used
+    # by any part of the Response. See commit
+    # 627593bbcd4ab52adc7ee569001cdda91c670d5d for rationale.
     request = None
     environ = None
 

--- a/webob/response.py
+++ b/webob/response.py
@@ -76,9 +76,9 @@ class Response(object):
     """
         Represents a WSGI response.
 
-        If no arguments are passed, creates a :py:class:`~Response` that uses a
+        If no arguments are passed, creates a :class:`~Response` that uses a
         variety of defaults. The defaults may be changed by sub-classing the
-        :py:class:`~Response`. See the :ref:`sub-classing notes
+        :class:`~Response`. See the :ref:`sub-classing notes
         <response_subclassing_notes>`.
 
         :cvar ~Response.body: If ``body`` is a ``text_type``, then it will be
@@ -88,7 +88,7 @@ class Response(object):
 
         :vartype ~Response.body: bytes or text_type
 
-        :cvar ~Response.status: Either an :py:class:`int` or a string that is
+        :cvar ~Response.status: Either an :class:`int` or a string that is
             an integer followed by the status text. If it is an integer, it
             will be converted to a proper status that also includes the status
             text.  Any existing status text will be kept. Non-standard values
@@ -113,8 +113,8 @@ class Response(object):
         :vartype ~Response.content_type: str or None
 
         :cvar conditional_response: Used to change the behavior of the
-            :py:class:`~Response` to check the original request for conditional
-            response headers. See :py:meth:`~Response.conditional_response_app`
+            :class:`~Response` to check the original request for conditional
+            response headers. See :meth:`~Response.conditional_response_app`
             for more information.
 
         :vartype conditional_response: bool
@@ -129,7 +129,7 @@ class Response(object):
         :vartype ~Response.charset: str or None
 
         All other response attributes may be set on the response by providing
-        them as keyword arguments. A :py:exc:`TypeError` will be raised for any
+        them as keyword arguments. A :exc:`TypeError` will be raised for any
         unexpected keywords.
 
         .. _response_subclassing_notes:
@@ -148,13 +148,13 @@ class Response(object):
           will not have a ``charset`` added.
 
         * The ``unicode_errors`` is set to ``strict``, and access on a
-          :py:attr:`~Response.text` will raise an error if it fails to decode the
-          :py:attr:`~Response.body`.
+          :attr:`~Response.text` will raise an error if it fails to decode the
+          :attr:`~Response.body`.
 
         * ``default_conditional_response`` is set to False. This flag may be
           set to True so that all ``Response`` objects will attempt to check
           the original request for conditional response headers. See
-          :py:meth:`~Response.conditional_response_app` for more information.
+          :meth:`~Response.conditional_response_app` for more information.
     """
 
     default_content_type = 'text/html'
@@ -435,7 +435,7 @@ class Response(object):
 
     def _body__get(self):
         """
-        The body of the response, as a :py:class:`bytes`.  This will read in
+        The body of the response, as a :class:`bytes`.  This will read in
         the entire app_iter if necessary.
         """
         app_iter = self._app_iter
@@ -495,10 +495,10 @@ class Response(object):
 
         .. note::
 
-           This will automatically :py:meth:`~bytes.decode` the
-           :py:attr:`~Response.body` as ``UTF-8`` on get, and
-           :py:meth:`~str.encode` the :py:meth:`json.dumps` as ``UTF-8``
-           before assigning to :py:attr:`~Response.body`.
+           This will automatically :meth:`~bytes.decode` the
+           :attr:`~Response.body` as ``UTF-8`` on get, and
+           :meth:`~str.encode` the :meth:`json.dumps` as ``UTF-8``
+           before assigning to :attr:`~Response.body`.
 
         """
         # Note: UTF-8 is a content-type specific default for JSON
@@ -514,9 +514,9 @@ class Response(object):
 
     def _has_body__get(self):
         """
-        Determine if the the response has a :py:attr:`~Response.body`. In
-        contrast to simply accessing :py:attr:`~Response.body` this method
-        will **not** read the underlying :py:attr:`~Response.app_iter`.
+        Determine if the the response has a :attr:`~Response.body`. In
+        contrast to simply accessing :attr:`~Response.body` this method
+        will **not** read the underlying :attr:`~Response.app_iter`.
         """
 
         app_iter = self._app_iter

--- a/webob/util.py
+++ b/webob/util.py
@@ -47,11 +47,11 @@ def header_docstring(header, rfc_section):
 
 def warn_deprecation(text, version, stacklevel):
     # version specifies when to start raising exceptions instead of warnings
-    if version in ('1.2', '1.3', '1.4'):
+    if version in ('1.2', '1.3', '1.4', '1.5', '1.6', '1.7'):
         raise DeprecationWarning(text)
     else:
         cls = DeprecationWarning
-    warnings.warn(text, cls, stacklevel=stacklevel+1)
+    warnings.warn(text, cls, stacklevel=stacklevel + 1)
 
 status_reasons = {
     # Status Codes


### PR DESCRIPTION
- Response.content_type removes charset unless the new content_type is a text like type that has a charset parameter
- Reverted change that was made in #253 whereby Response.charset would not allow the user to set a charset if the content type was JSON. I am not a big fan of trying to stop the user from shooting themselves in the foot, and would rather let them add/remove as needed.
- json.dumps/loads are now always UTF-8. Python returns a string to us, and we can encode it as we see fit.
- `Response.__init__` has been cleaned up to remove a lot of extraneous branch conditions that were only complicating the logic.