### PR TITLE
request: read body from file if the method is DELETE

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2890,6 +2890,14 @@ class TestRequest_functional(object):
         assert req.body in _test_req_patch
         assert _test_req_patch == req.as_bytes()
 
+    def test_from_file_delete(self):
+        cls = self._getTargetClass()
+        req = cls.from_bytes(_test_req_delete)
+        assert "DELETE" == req.method
+        assert len(req.body)
+        assert req.body in _test_req_delete
+        assert _test_req_delete == req.as_bytes()
+
     def test_from_bytes(self):
         # A valid request without a Content-Length header should still read
         # the full body.
@@ -3613,6 +3621,14 @@ Content-Type: application/json
 {"foo": "bar"}
 """
 
+_test_req_delete = b"""
+DELETE /webob HTTP/1.1
+Content-Length: 14
+Content-Type: application/json
+
+{"foo": "bar"}
+"""
+
 _test_req2 = b"""
 POST / HTTP/1.0
 Content-Length: 0
@@ -3657,6 +3673,7 @@ Content-Disposition: form-data; name=file; filename="photo.jpg"
 
 _test_req = _norm_req(_test_req)
 _test_req_patch = _norm_req(_test_req_patch)
+_test_req_delete = _norm_req(_test_req_delete)
 _test_req2 = _norm_req(_test_req2) + b'\r\n'
 _test_req_multipart_charset = _norm_req(_test_req_multipart_charset)
 

--- a/tests/test_request_nose.py
+++ b/tests/test_request_nose.py
@@ -48,7 +48,7 @@ def test_request_readlines():
 
 def test_request_delete_with_body():
     req = Request.blank('/', method='DELETE')
-    assert not req.is_body_readable
+    assert req.is_body_readable
     req.body = b'abc'
     assert req.is_body_readable
     assert req.body_file.read() == b'abc'

--- a/webob/request.py
+++ b/webob/request.py
@@ -89,9 +89,9 @@ NoDefault = _NoDefault()
 PATH_SAFE = '/:@&+$,'
 
 http_method_probably_has_body = dict.fromkeys(
-    ('GET', 'HEAD', 'DELETE', 'TRACE'), False)
+    ('GET', 'HEAD', 'TRACE'), False)
 http_method_probably_has_body.update(
-    dict.fromkeys(('POST', 'PUT', 'PATCH'), True))
+    dict.fromkeys(('POST', 'PUT', 'PATCH', 'DELETE'), True))
 
 _LATIN_ENCODINGS = (
     'ascii', 'latin-1', 'latin', 'latin_1', 'l1', 'latin1',


### PR DESCRIPTION
Currently Request.from_file ignore the body of a request if the method is
DELETE. This fixes that by using the dictionary we have to know if a request
might have a body or not.