### PR TITLE
Fix: bodies on everything

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3677,7 +3677,8 @@ class UnseekableInput(object):
             self.pos = len(self.data)
             return t
         else:
-            assert(self.pos + size <= len(self.data))
+            if self.pos + size > len(self.data):
+                size = len(self.data) - self.pos
             t = self.data[self.pos:self.pos + size]
             self.pos += size
             return t

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -670,24 +670,23 @@ class TestRequestCommon(object):
         assert req.range == None
 
     def test_is_body_readable_POST(self):
-        req = self._blankOne('/', environ={'REQUEST_METHOD':'POST'})
+        req = self._blankOne('/', environ={'REQUEST_METHOD': 'POST', 'CONTENT_LENGTH': '100'})
         assert req.is_body_readable
 
     def test_is_body_readable_PATCH(self):
-        req = self._blankOne('/', environ={'REQUEST_METHOD':'PATCH'})
+        req = self._blankOne('/', environ={'REQUEST_METHOD': 'PATCH', 'CONTENT_LENGTH': '100'})
         assert req.is_body_readable
 
     def test_is_body_readable_GET(self):
-        req = self._blankOne('/', environ={'REQUEST_METHOD':'GET'})
-        assert req.is_body_readable == False
+        req = self._blankOne('/', environ={'REQUEST_METHOD': 'GET', 'CONTENT_LENGTH': '100'})
+        assert req.is_body_readable
 
     def test_is_body_readable_unknown_method_and_content_length(self):
-        req = self._blankOne('/', environ={'REQUEST_METHOD':'WTF'})
-        req.content_length = 10
+        req = self._blankOne('/', environ={'REQUEST_METHOD': 'WTF', 'CONTENT_LENGTH': '100'})
         assert req.is_body_readable
 
     def test_is_body_readable_special_flag(self):
-        req = self._blankOne('/', environ={'REQUEST_METHOD':'WTF',
+        req = self._blankOne('/', environ={'REQUEST_METHOD': 'WTF',
                                           'webob.is_body_readable': True})
         assert req.is_body_readable
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -101,7 +101,7 @@ class TestRequestCommon(object):
 
     def test_body_file_setter_w_bytes(self):
         req = self._blankOne('/')
-        with pytest.raises(DeprecationWarning):
+        with pytest.raises(ValueError):
             setattr(req, 'body_file', b'foo')
 
     def test_body_file_setter_non_bytes(self):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2833,6 +2833,10 @@ class TestRequest_functional(object):
 
         r.body = None
         assert r.body == b''
+
+        no_seek = UnseekableInput(bytes_(string.ascii_letters))
+
+        r = self._makeOne({'a': 1}, method='PUT', body_file=no_seek)
         assert not hasattr(r.body_file_raw, 'seek')
 
         r.make_body_seekable()

--- a/tests/test_request_nose.py
+++ b/tests/test_request_nose.py
@@ -75,11 +75,16 @@ class ReadTracker(object):
     def __init__(self, data):
         self.data = data
         self.was_read = False
+
     def read(self, size=-1):
-        if size < 0:
+        if size < 0 or size > len(self.data):
             size = len(self.data)
-        assert size == len(self.data)
+
+        if self.was_read:
+            return b''
+
         self.was_read = True
+
         return self.data
 
 def test_limited_length_file_repr():
@@ -117,6 +122,9 @@ class _Helper_test_request_wrong_clen(object):
                 raise AssertionError("Reading should stop after first empty string")
             self.file_ended = True
         return r
+
+    def seek(self, pos):
+        pass
 
 def test_disconnect_detection_cgi():
     data = 'abc'*(1<<20)

--- a/tests/test_request_nose.py
+++ b/tests/test_request_nose.py
@@ -15,8 +15,14 @@ def test_request_read_no_content_length():
 def test_request_read_no_content_length_POST():
     req, input = _make_read_tracked_request(b'abc', 'POST')
     assert req.content_length is None
-    assert req.body == b'abc'
-    assert input.was_read
+    assert req.body == b''
+    assert not input.was_read
+
+def test_request_read_no_content_length_DELETE():
+    req, input = _make_read_tracked_request(b'abc', 'DELETE')
+    assert req.content_length is None
+    assert req.body == b''
+    assert not input.was_read
 
 def test_request_read_no_flag_but_content_length_is_present():
     req, input = _make_read_tracked_request(b'abc')

--- a/webob/request.py
+++ b/webob/request.py
@@ -28,7 +28,6 @@ from webob.cachecontrol import (
 from webob.compat import (
     PY3,
     bytes_,
-    integer_types,
     native_,
     parse_qsl_text,
     reraise,
@@ -76,8 +75,6 @@ from webob.multidict import (
     NoVars,
     GetDict,
     )
-
-from webob.util import warn_deprecation
 
 __all__ = ['BaseRequest', 'Request', 'LegacyRequest']
 

--- a/webob/request.py
+++ b/webob/request.py
@@ -1565,6 +1565,13 @@ cgi_FieldStorage.__repr__ = _cgi_FieldStorage__repr__patch
 
 class FakeCGIBody(io.RawIOBase):
     def __init__(self, vars, content_type):
+        warnings.warn(
+            "FakeCGIBody is no longer used by WebOb and will be removed from a future "
+            "version of WebOb. If you require FakeCGIBody please make a copy into "
+            "you own project",
+            DeprecationWarning
+            )
+
         if content_type.startswith('multipart/form-data'):
             if not _get_multipart_boundary(content_type):
                 raise ValueError('Content-type: %r does not contain boundary'

--- a/webob/request.py
+++ b/webob/request.py
@@ -683,7 +683,7 @@ class BaseRequest(object):
         """
         domain = self.host
         if ':' in domain:
-             domain = domain.split(':', 1)[0]
+            domain = domain.split(':', 1)[0]
         return domain
 
     @property

--- a/webob/request.py
+++ b/webob/request.py
@@ -893,8 +893,8 @@ class BaseRequest(object):
     @property
     def is_body_readable(self):
         """
-            webob.is_body_readable is a flag that tells us that we can read the
-            input stream even though CONTENT_LENGTH is missing.
+        webob.is_body_readable is a flag that tells us that we can read the
+        input stream even though CONTENT_LENGTH is missing.
         """
 
         clen = self.content_length

--- a/webob/request.py
+++ b/webob/request.py
@@ -686,33 +686,33 @@ class BaseRequest(object):
              domain = domain.split(':', 1)[0]
         return domain
 
-    def _body__get(self):
+    @property
+    def body(self):
         """
         Return the content of the request body.
         """
         if not self.is_body_readable:
             return b''
+
         self.make_body_seekable() # we need this to have content_length
         r = self.body_file.read(self.content_length)
         self.body_file_raw.seek(0)
         return r
-    def _body__set(self, value):
+
+    @body.setter
+    def body(self, value):
         if value is None:
             value = b''
         if not isinstance(value, bytes):
             raise TypeError("You can only set Request.body to bytes (not %r)"
-                                % type(value))
-        if not http_method_probably_has_body.get(self.method, True):
-            if not value:
-                self.content_length = None
-                self.body_file_raw = io.BytesIO()
-                return
+                            % type(value))
         self.content_length = len(value)
         self.body_file_raw = io.BytesIO(value)
         self.is_body_seekable = True
-    def _body__del(self):
+
+    @body.deleter
+    def body(self):
         self.body = b''
-    body = property(_body__get, _body__set, _body__del, doc=_body__get.__doc__)
 
     def _json_body__get(self):
         """Access the body of the request as JSON"""


### PR DESCRIPTION
This removes the implicit support of Chunked Encoding within WebOb. WebOb now treats all Requests as body-less unless the Content-Length header is set. This also means that every single HTTP verb (and unknown ones if you'd like :-P) are now allowed to have a body on it, and using wsgiref no longer hangs on non-existent bodies.

```
from wsgiref.simple_server import make_server
from webob import Request, Response

class MyApp(object):
    def __call__(self, environ, start_response):
        request = Request(environ)
        response = Response()
        print(request.method)
        print(request.body)
        response.body = b'Received: ' + request.body
        return response(environ, start_response)

httpd = make_server('localhost', 8080, MyApp())
try:
    httpd.serve_forever()
except KeyboardInterrupt:
    print('^C')
```

test with:

```
curl -X DELETE --data 'mydata' http://localhost:8080/
curl -X POST http://localhost:8080/ # No longer hangs
curl -X DELETE http://localhost:8080/
curl -X GET --data 'otherdata' http://localhost:8080/
```

The proposal in #278 has not yet been implemented.

Closes: #279, #233, #116
Supersedes: #274