### PR TITLE
Move the _lazified class out of the lazify function

### DIFF
--- a/webob/exc.py
+++ b/webob/exc.py
@@ -185,13 +185,18 @@ tag_re = re.compile(r'<.*?>', re.S)
 br_re = re.compile(r'<br.*?>', re.I | re.S)
 comment_re = re.compile(r'<!--|-->')
 
+class _lazified(object):
+    def __init__(self, func, value):
+        self.func = func
+        self.value = value
+
+    def __str__(self):
+        return self.func(self.value)
+
 def lazify(func):
-    class _lazyfied(object):
-        def __init__(self, s):
-            self._s = s
-        def __str__(self):
-            return func(self._s)
-    return _lazyfied
+    def wrapper(value):
+        return _lazified(func, value)
+    return wrapper
 
 def no_escape(value):
     if value is None:


### PR DESCRIPTION
Capturing the function, and returning a new object from a class that is
defined within the capturing function seems to cause some sort of really
pathological behavior that causes lazify() to take up a bunch of CPU
time, especially when it is part of a hot code path.

Thanks to Martijn Faassen (@faassen) for reporting! 

Closes #282