### PR TITLE
Performance: Response

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3282,7 +3282,7 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain')]
         assert res.body == b'Hi!'
 
     def test_call_WSGI_app_204(self):
@@ -3329,7 +3329,7 @@ class TestRequest_functional(object):
         assert res.status == '200 OK'
         from webob.headers import ResponseHeaders
         assert isinstance(res.headers, ResponseHeaders)
-        assert list(res.headers.items()) == [('Content-Type', 'text/plain; charset=UTF-8')]
+        assert list(res.headers.items()) == [('Content-Type', 'text/plain')]
         assert res.body == b'Hi!'
 
     def equal_req(self, req, inp):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1268,3 +1268,8 @@ def test_explicit_charset():
     res = Response(charset='UTF-16')
     assert res.content_type == 'text/html'
     assert res.charset == 'UTF-16'
+
+def test_set_content_type():
+    res = Response(content_type='application/json')
+    res.content_type = 'application/foo'
+    assert res.content_type == 'application/foo'

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1288,3 +1288,27 @@ def test_set_content_type():
     res = Response(content_type='application/json')
     res.content_type = 'application/foo'
     assert res.content_type == 'application/foo'
+
+def test_raises_no_charset():
+    with pytest.raises(TypeError):
+        Response(content_type='image/jpeg', body=text_(b'test'))
+
+def test_raises_none_charset():
+    with pytest.raises(TypeError):
+        Response(
+            content_type='image/jpeg',
+            body=text_(b'test'),
+            charset=None)
+
+def test_doesnt_raise_with_charset_content_type_has_no_charset():
+    res = Response(content_type='image/jpeg', body=text_(b'test'), charset='utf-8')
+    assert res.body == b'test'
+    assert res.content_type == 'image/jpeg'
+    assert res.charset is None
+
+def test_content_type_has_charset():
+    res = Response(content_type='application/foo; charset=UTF-8', body=text_(b'test'))
+    assert res.body == b'test'
+    assert res.content_type == 'application/foo'
+    assert res.charset == 'UTF-8'
+    assert res.headers['Content-Type'] == 'application/foo; charset=UTF-8'

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1182,20 +1182,35 @@ def test_decode_content_gzip():
     res.decode_content()
     assert res.body == b'abc'
 
-def test__abs_headerlist_location_with_scheme():
-    res = Response()
-    res.content_encoding = 'gzip'
-    res.headerlist = [('Location', 'http:')]
-    result = res._abs_headerlist({})
-    assert result, [('Location' == 'http:')]
+def test__make_location_absolute_has_scheme_only():
+    result = Response._make_location_absolute(
+        {
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'example.com:80'
+        },
+        'http:'
+    )
+    assert result == 'http:'
 
-def test__abs_headerlist_location_no_scheme():
-    res = Response()
-    res.content_encoding = 'gzip'
-    res.headerlist = [('Location', '/abc')]
-    result = res._abs_headerlist({'wsgi.url_scheme': 'http',
-                                  'HTTP_HOST': 'example.com:80'})
-    assert result == [('Location', 'http://example.com/abc')]
+def test__make_location_absolute_path():
+    result = Response._make_location_absolute(
+        {
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'example.com:80'
+        },
+        '/abc'
+    )
+    assert result == 'http://example.com/abc'
+
+def test__make_location_absolute_already_absolute():
+    result = Response._make_location_absolute(
+        {
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'example.com:80'
+        },
+        'https://funcptr.net/'
+    )
+    assert result == 'https://funcptr.net/'
 
 def test_response_set_body_file1():
     data = b'abc'

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -18,7 +18,7 @@ def teardown_module(module):
 
 def simple_app(environ, start_response):
     start_response('200 OK', [
-        ('Content-Type', 'text/html; charset=utf8'),
+        ('Content-Type', 'text/html; charset=UTF-8'),
         ])
     return ['OK']
 
@@ -28,7 +28,7 @@ def test_response():
     assert res.status == '200 OK'
     assert res.status_code == 200
     assert res.body == "OK"
-    assert res.charset == 'utf8'
+    assert res.charset == "UTF-8"
     assert res.content_type == 'text/html'
     res.status = 404
     assert res.status == '404 Not Found'
@@ -158,7 +158,7 @@ def test_cookies():
     r2 = res.merge_cookies(simple_app)
     r2 = BaseRequest.blank('/').get_response(r2)
     assert r2.headerlist == [
-        ('Content-Type', 'text/html; charset=utf8'),
+        ('Content-Type', 'text/html; charset=UTF-8'),
         ('Set-Cookie', 'x=test; Path=/'),
         ]
 
@@ -475,19 +475,6 @@ def test_has_body():
     messing_with_privates = Response()
     messing_with_privates._app_iter = None
     assert not messing_with_privates.has_body
-
-def test_content_type_in_headerlist():
-    # Couldn't manage to clone Response in order to modify class
-    # attributes safely. Shouldn't classes be fresh imported for every
-    # test?
-    default_content_type = Response.default_content_type
-    Response.default_content_type = None
-    try:
-        res = Response(headerlist=[('Content-Type', 'text/html')], charset='utf8')
-        assert res._headerlist
-        assert res.charset == 'utf8'
-    finally:
-        Response.default_content_type = default_content_type
 
 def test_str_crlf():
     res = Response('test')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -976,6 +976,7 @@ def test_cache_control_get():
 
 def test_location():
     res = Response()
+    res.status = '301'
     res.location = '/test.html'
     assert res.location == '/test.html'
     req = Request.blank('/')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1228,3 +1228,43 @@ def test_cache_expires_set_zero_then_nonzero():
     assert not res.cache_control.no_store
     assert not res.cache_control.must_revalidate
     assert res.cache_control.max_age == 1
+
+def test_default_content_type():
+    class NoDefault(Response):
+        default_content_type = None
+
+    res = NoDefault()
+    assert res.content_type is None
+
+def test_default_charset():
+    class DefaultCharset(Response):
+        default_charset = 'UTF-16'
+
+    res = DefaultCharset()
+    assert res.content_type == 'text/html'
+    assert res.charset == 'UTF-16'
+    assert res.headers['Content-Type'] == 'text/html; charset=UTF-16'
+
+def test_header_list_no_defaults():
+    res = Response(headerlist=[])
+    assert res.headerlist == [('Content-Length', '0')]
+    assert res.content_type is None
+    assert res.charset is None
+    assert res.body == b''
+
+def test_204_has_no_body():
+    res = Response(status='204 No Content')
+    assert res.body == b''
+    assert res.content_length is None
+    assert res.headerlist == []
+
+def test_204_app_iter_set():
+    res = Response(status='204', app_iter=[b'test'])
+    assert res.body == b''
+    assert res.content_length is None
+    assert res.headerlist == []
+
+def test_explicit_charset():
+    res = Response(charset='UTF-16')
+    assert res.content_type == 'text/html'
+    assert res.charset == 'UTF-16'

--- a/webob/descriptors.py
+++ b/webob/descriptors.py
@@ -146,10 +146,7 @@ def header_getter(header, rfc_section):
             r._headerlist.append((header, value))
 
     def fdel(r):
-        items = r._headerlist
-        for i in range(len(items)-1, -1, -1):
-            if items[i][0].lower() == key:
-                del items[i]
+        r._headerlist[:] = [(k, v) for (k, v) in r._headerlist if k.lower() != key]
 
     return property(fget, fset, fdel, doc)
 

--- a/webob/headers.py
+++ b/webob/headers.py
@@ -42,10 +42,7 @@ class ResponseHeaders(MultiDict):
 
     def __setitem__(self, key, value):
         norm_key = key.lower()
-        items = self._items
-        for i in range(len(items)-1, -1, -1):
-            if items[i][0].lower() == norm_key:
-                del items[i]
+        self._items[:] = [(k, v) for (k, v) in self._items if k.lower() != norm_key]
         self._items.append((key, value))
 
     def __delitem__(self, key):

--- a/webob/headers.py
+++ b/webob/headers.py
@@ -21,11 +21,7 @@ class ResponseHeaders(MultiDict):
 
     def getall(self, key):
         key = key.lower()
-        result = []
-        for k, v in self._items:
-            if k.lower() == key:
-                result.append(v)
-        return result
+        return [v for (k, v) in self._items if k.lower() == key]
 
     def mixed(self):
         r = self.dict_of_lists()

--- a/webob/response.py
+++ b/webob/response.py
@@ -439,7 +439,7 @@ class Response(object):
         The headers in a dictionary-like object
         """
         if self._headers is None:
-            self._headers = ResponseHeaders.view_list(self.headerlist)
+            self._headers = ResponseHeaders.view_list(self._headerlist)
         return self._headers
 
     def _headers__set(self, value):

--- a/webob/response.py
+++ b/webob/response.py
@@ -225,7 +225,7 @@ class Response(object):
         encoding = None
         code_has_body = (
             self._status[0] != '1' and
-            self._status[:3] not in ('204', '304')
+            self._status[:3] not in ('204', '205', '304')
         )
         if headerlist is None and code_has_body:
             content_type = content_type or self.default_content_type


### PR DESCRIPTION
Based on comments made in #285 I took a look at seeing what could be done to get some of the speed back in the synthetic test that `howareyou` provides.

In that ticket there is a patchset that brings it back to within 2k rps in the benchmark. However the maintenance burden goes up drastically, and I don't think the additional burden is worth the cost.

The new and updated `Response.__init__` is more correct, and has more code re-use by calling various properties/functions rather than trying to do it all. There is a sacrifice, but ultimately WebOb and it's `Response` object are not going to be the bottleneck, especially because outside of the synthetic test that attempts to return a `Response` object as fast as possible user code is going to dominate in cases where WebOb is used.

----

Update: After talking about the way that `Response.__init__` works with @mmerickel , a bunch of mis-features that used to exist have been removed:

If the user provides a headerlist, Response.__init__ will no longer attempt to set the default Content-Type, nor will __init__ add a charset to any existing Content-Type.

The Content-Type will only be set if no headerlist is provided, and the HTTP status code allows for a body. The charset will be set only if there is no charset on the Content-Type provided.

    resp = Response(headerlist=[], content_type='text/plain', charset='UTF-8')

will have a headerlist that is: `resp.headerlist == [('Content-Length', '0')]`

    resp = Response(status='204 No Content')

will have a headerlist that is: `resp.headerlist == []`

`__init__` will now also ignore body/app_iter if the status code has no body (100-199, 204, 304)

    resp = Response(status='204 No Content', app_iter=[b'test'])

Will not have a `Content-Length`, and `resp.body` will return `b''`. If you would like to violate HTTP standards, you may of course do:

    resp = Response(status='204 No Content')
    resp.body = b'test'

`__init__` won't let you create an invalid response, what you do with the returned response however is up to you.

Closes #285 