### PR TITLE
Bugfix: set_cookie datetime

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -860,6 +860,36 @@ def test_set_cookie_expires_is_timedelta_and_max_age_is_None():
     assert val[2] == 'a=1'
     assert val[3].startswith('expires')
 
+def test_set_cookie_expires_is_datetime_tz_and_max_age_is_None():
+    import datetime
+    res = Response()
+
+    class FixedOffset(datetime.tzinfo):
+        def __init__(self, offset, name):
+            self.__offset = datetime.timedelta(minutes=offset)
+            self.__name = name
+
+        def utcoffset(self, dt):
+            return self.__offset
+
+        def tzname(self, dt):
+            return self.__name
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
+    then = datetime.datetime.now(FixedOffset(60, 'UTC+1')) + datetime.timedelta(days=1)
+
+    res.set_cookie('a', '1', expires=then)
+    assert res.headerlist[-1][0] == 'Set-Cookie'
+    val = [x.strip() for x in res.headerlist[-1][1].split(';')]
+    assert len(val) == 4
+    val.sort()
+    assert val[0] in ('Max-Age=86399', 'Max-Age=86400')
+    assert val[1] == 'Path=/'
+    assert val[2] == 'a=1'
+    assert val[3].startswith('expires')
+
 def test_delete_cookie():
     res = Response()
     res.headers['Set-Cookie'] = 'a=2; Path=/'

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -832,7 +832,7 @@ def test_set_cookie_expires_is_None_and_max_age_is_timedelta():
     assert val[2] == 'a=1'
     assert val[3].startswith('expires')
 
-def test_set_cookie_expires_is_not_None_and_max_age_is_None():
+def test_set_cookie_expires_is_datetime_and_max_age_is_None():
     import datetime
     res = Response()
     then = datetime.datetime.utcnow() + datetime.timedelta(days=1)

--- a/webob/response.py
+++ b/webob/response.py
@@ -1021,12 +1021,25 @@ class Response(object):
            If ``max_age`` is set, it will be used to generate the ``expires``
            and this value is ignored.
 
+           If a ``datetime.datetime`` is provided it has to either be timezone
+           aware or be based on UTC. ``datetime.datetime`` objects that are
+           local time are not supported. Timezone aware ``datetime.datetime``
+           objects are converted to UTC.
+
+           This argument will be removed in future
+           versions of WebOb (version 1.9).
+
         ``overwrite``
 
            If this key is ``True``, before setting the cookie, unset any
            existing cookie.
 
         """
+
+        # Remove in WebOb 1.9
+        if expires:
+            warn_deprecation('Argument "expires" will be removed in a future '
+                             'version of WebOb, please use "max_age".', 1.9, 1)
 
         if name is None:
             raise TypeError('set_cookie() takes at least 1 argument')
@@ -1040,6 +1053,11 @@ class Response(object):
 
         # expires can also be a datetime
         if not max_age and isinstance(expires, datetime):
+
+            # If expires has a timezone attached, convert it to UTC
+            if expires.tzinfo and expires.utcoffset():
+                expires = (expires - expires.utcoffset()).replace(tzinfo=None)
+
             max_age = expires - datetime.utcnow()
 
         value = bytes_(value, 'utf-8')

--- a/webob/response.py
+++ b/webob/response.py
@@ -1036,10 +1036,10 @@ class Response(object):
 
         """
 
-        # Remove in WebOb 1.9
+        # Remove in WebOb 1.10
         if expires:
             warn_deprecation('Argument "expires" will be removed in a future '
-                             'version of WebOb, please use "max_age".', 1.9, 1)
+                             'version of WebOb, please use "max_age".', 1.10, 1)
 
         if name is None:
             raise TypeError('set_cookie() takes at least 1 argument')


### PR DESCRIPTION
This fixes the bug reported by @dobesv in #254. Also documents that `expires` should not be a localtime, and that it should not be set in the past.

