### PR TITLE
Feature: remove ctype params

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -232,9 +232,9 @@ argument to the class, e.g.:
 
   response = Response(body='hello world!', content_type='text/plain')
 
-The status defaults to ``'200 OK'``.  The content_type does not
-default to anything, although if you subclass ``Response`` and set
-``default_content_type``, you can override this behavior.
+The status defaults to ``'200 OK'``. The content_type defaults to
+``default_content_type`` which is set to `text/html`, although if you subclass
+``Response`` and set ``default_content_type``, you can override this behavior.
 
 Exceptions
 ==========

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -39,7 +39,7 @@ def test_response():
     res.charset = 'iso8859-1'
     assert 'text/html; charset=iso8859-1' == res.headers['content-type']
     res.content_type = 'text/xml'
-    assert 'text/xml; charset=iso8859-1' == res.headers['content-type']
+    assert 'text/xml; charset=UTF-8' == res.headers['content-type']
     res.content_type = 'text/xml; charset=UTF-8'
     assert 'text/xml; charset=UTF-8' == res.headers['content-type']
     res.headers = {'content-type': 'text/html'}

--- a/webob/response.py
+++ b/webob/response.py
@@ -12,8 +12,6 @@ try:
 except ImportError:
     import json
 
-import warnings
-
 from webob.byterange import ContentRange
 
 from webob.cachecontrol import (

--- a/webob/response.py
+++ b/webob/response.py
@@ -838,14 +838,12 @@ class Response(object):
 
         .. versionchanged:: 1.7
 
-            Setting a new Content-Type will remove charset from the
-            Content-Type parameters if the Content-Type is not ``text/*`` or XML
-            (``application/xml``, or ``*/*+xml``)
+            Setting a new Content-Type will remove all Content-Type parameters
+            and reset the charset to the default if the Content-Type is
+            ``text/*`` or XML (``application/xml``, or ``*/*+xml``)
 
-            In the future all parameters will be deleted upon changing the
-            Content-Type, if you explicitly want to transfer over existing
-            parameters, you may retrieve them with ``content_type_params`` and
-            set them after setting ``content_type``.
+            To preserve all Content-Type parameters you may use the following
+            code:
 
             .. code::
 
@@ -853,12 +851,6 @@ class Response(object):
                 params = resp.content_type_params
                 resp.content_type = 'application/something'
                 resp.content_type_params = params
-
-        .. deprecated:: 1.7
-
-            If you include parameters (or ``;`` at all) when setting the
-            content_type, any existing parameters will be deleted;
-            otherwise they will be preserved.
         """
         header = self.headers.get('Content-Type')
         if not header:


### PR DESCRIPTION
This rips the band-aid off from the whole content-type parameters, and always removes them.

@mmerickel approved.