### PR TITLE
Prevent leaking if file exists outside of static path

### DIFF
--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -192,6 +192,17 @@ class TestDirectoryApp(unittest.TestCase):
         # The file exists, but is outside the served dir.
         self.assertEqual(403, get_response(app, '/../bar').status_code)
 
+    def test_dont_leak_parent_directory_file_existance(self):
+        # We'll have:
+        #   /TEST_DIR/
+        #   /TEST_DIR/foo/   <- serve this directory
+        serve_path = os.path.join(self.test_dir, 'foo')
+        os.mkdir(serve_path)
+        app = static.DirectoryApp(serve_path)
+
+        # The file exists, but is outside the served dir.
+        self.assertEqual(403, get_response(app, '/../bar2').status_code)
+
     def test_file_app_arguments(self):
         app = static.DirectoryApp(self.test_dir, content_type='xxx/yyy')
         create_file('abcde', self.test_dir, 'bar')

--- a/webob/static.py
+++ b/webob/static.py
@@ -147,10 +147,10 @@ class DirectoryApp(object):
             return Response(
                 status=301,
                 location=new_url)
-        if not os.path.isfile(path):
-            return exc.HTTPNotFound(comment=path)
-        elif not path.startswith(self.path):
+        if not path.startswith(self.path):
             return exc.HTTPForbidden()
+        elif not os.path.isfile(path):
+            return exc.HTTPNotFound(comment=path)
         else:
             return self.make_fileapp(path)
 


### PR DESCRIPTION
This fix prevents the static.DirectoryApp from leaking that a file exists
outside of the given path by first checking if the path is correct
before testing if the file exists.