### PR TITLE
Fix BytesWarning in webob.cookies._value_quote

### DIFF
--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -402,7 +402,7 @@ def _value_quote(v):
     leftovers = v.translate(None, _allowed_cookie_bytes)
     if leftovers:
         __warn_or_raise(
-                "Cookie value contains invalid bytes: (%s). Future versions "
+                "Cookie value contains invalid bytes: (%r). Future versions "
                 "will raise ValueError upon encountering invalid bytes." %
                 (leftovers,),
                 RuntimeWarning, ValueError, 'Invalid characters in cookie value'


### PR DESCRIPTION
When running Python 3 with the `-b` option, calling str() on a bytes instance raises a warning. This came up for us when running code with `-bb` enabled (which frequently helps catch bugs).