### PR TITLE
Change AcceptClass of request.accept_encoding to AcceptEncoding.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,11 @@ Backwards Incompatibilities
   ``content_md5`` and then returning an iterator for chunked content encoded
   responses. See https://github.com/Pylons/webob/issues/86
 
+- The ``accept_encoding`` property on a ``Request`` object now returns an
+  instance of ``webob.acceptparse.AcceptEncoding`` rather than
+  ``webob.acceptparse.Accept`` when the ``Accept-Encoding`` header is a truthy
+  value. See https://github.com/Pylons/webob/issues/325
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -232,6 +232,13 @@ class AcceptCharset(Accept):
         if not latin1_found:
             yield ('iso-8859-1', 1)
 
+
+class AcceptEncoding(Accept):
+    """
+    Represents an ``Accept-Encoding`` header.
+    """
+
+
 class AcceptLanguage(Accept):
     def _match(self, mask, item):
         item = item.replace('_', '-').lower()

--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -12,6 +12,7 @@ except ImportError:
 import warnings
 
 from webob.acceptparse import (
+    AcceptEncoding,
     AcceptLanguage,
     AcceptCharset,
     MIMEAccept,
@@ -1041,6 +1042,7 @@ class BaseRequest(object):
     accept = accept_property('Accept', '14.1', MIMEAccept, MIMENilAccept)
     accept_charset = accept_property('Accept-Charset', '14.2', AcceptCharset)
     accept_encoding = accept_property('Accept-Encoding', '14.3',
+                                      AcceptClass=AcceptEncoding,
                                       NilClass=NoAccept)
     accept_language = accept_property('Accept-Language', '14.4', AcceptLanguage)
 


### PR DESCRIPTION
Having ``request.accept_encoding`` return an ``Accept`` class was
strange and confusing, but more importantly the header needs its own
class for ``Accept-Encoding``-specific functionality. (See
https://github.com/Pylons/webob/issues/325)

Thanks!