### PR TITLE
Document acceptparse classes

### DIFF
--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -6,12 +6,49 @@ Headers
 
 Accept-*
 ~~~~~~~~
+.. # 2017-06-16: There appears to be various bugs with the ``:members`` and
+.. # ``:inherited-members`` options, both when the two are used together, and
+.. # when one of them is combined with ``autoattribute``, so we are using
+.. # ``automethod`` and ``autoattribute`` instead.
 
 .. automodule:: webob.acceptparse
-.. autoclass:: Accept
-   :members:
+
+.. autoclass:: AcceptCharset
+
+   .. automethod:: best_match
+   .. automethod:: quality
+
+.. autoclass:: AcceptEncoding
+
+   .. automethod:: best_match
+   .. automethod:: quality
+
+.. autoclass:: AcceptLanguage
+
+   .. automethod:: best_match
+   .. automethod:: quality
+
 .. autoclass:: MIMEAccept
-   :members:
+
+   .. autoattribute:: accepts_html
+   .. automethod:: accept_html
+   .. automethod:: best_match
+   .. automethod:: quality
+
+.. autoclass:: MIMENilAccept
+
+   .. automethod:: best_match
+   .. automethod:: quality
+
+.. autoclass:: NilAccept
+
+   .. automethod:: best_match
+   .. automethod:: quality
+
+.. autoclass:: NoAccept
+
+   .. automethod:: best_match
+   .. automethod:: quality
 
 Cache-Control
 ~~~~~~~~~~~~~

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -16,16 +16,19 @@ Accept-*
 .. autoclass:: AcceptCharset
 
    .. automethod:: best_match
+   .. automethod:: parse
    .. automethod:: quality
 
 .. autoclass:: AcceptEncoding
 
    .. automethod:: best_match
+   .. automethod:: parse
    .. automethod:: quality
 
 .. autoclass:: AcceptLanguage
 
    .. automethod:: best_match
+   .. automethod:: parse
    .. automethod:: quality
 
 .. autoclass:: MIMEAccept
@@ -33,6 +36,7 @@ Accept-*
    .. autoattribute:: accepts_html
    .. automethod:: accept_html
    .. automethod:: best_match
+   .. automethod:: parse
    .. automethod:: quality
 
 .. autoclass:: MIMENilAccept

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -6,11 +6,6 @@ Headers
 
 Accept-*
 ~~~~~~~~
-.. # 2017-06-16: There appears to be various bugs with the ``:members`` and
-.. # ``:inherited-members`` options, both when the two are used together, and
-.. # when one of them is combined with ``autoattribute``, so we are using
-.. # ``automethod`` and ``autoattribute`` instead.
-
 .. automodule:: webob.acceptparse
 
 .. autoclass:: AcceptCharset

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -234,6 +234,11 @@ class AcceptCharset(Accept):
     """
     @staticmethod
     def parse(value):
+        """
+        Parse ``Accept-Charset`` header.
+
+        Return iterator of ``(charset, qvalue)`` pairs.
+        """
         latin1_found = False
         for m, q in Accept.parse(value):
             _m = m.lower()
@@ -272,6 +277,11 @@ class MIMEAccept(Accept):
     """
     @staticmethod
     def parse(value):
+        """
+        Parse ``Accept`` header.
+
+        Return iterator of ``(media range, qvalue)`` pairs.
+        """
         for mask, q in Accept.parse(value):
             try:
                 mask_major, mask_minor = [x.lower() for x in mask.split('/')]

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -168,6 +168,10 @@ class Accept(object):
 
 
 class NilAccept(object):
+    """
+    Represents a generic ``Accept-*`` style header when it is not present in
+    the request or is empty.
+    """
     MasterClass = Accept
 
     def __repr__(self):
@@ -217,10 +221,17 @@ class NilAccept(object):
         return best_offer
 
 class NoAccept(NilAccept):
+    """
+    Represents an ``Accept-Encoding`` header when it is not present in the
+    request or is empty.
+    """
     def __contains__(self, item):
         return False
 
 class AcceptCharset(Accept):
+    """
+    Represents an ``Accept-Charset`` header.
+    """
     @staticmethod
     def parse(value):
         latin1_found = False
@@ -240,6 +251,9 @@ class AcceptEncoding(Accept):
 
 
 class AcceptLanguage(Accept):
+    """
+    Represents an ``Accept-Language`` header.
+    """
     def _match(self, mask, item):
         item = item.replace('_', '-').lower()
         mask = mask.lower()
@@ -252,9 +266,9 @@ class AcceptLanguage(Accept):
 
 class MIMEAccept(Accept):
     """
-        Represents the ``Accept`` header, which is a list of mimetypes.
+    Represents an ``Accept`` header, which is a list of mimetypes.
 
-        This class knows about mime wildcards, like ``image/*``
+    This class knows about mime wildcards, like ``image/*``
     """
     @staticmethod
     def parse(value):
@@ -340,6 +354,10 @@ class MIMEAccept(Accept):
 
 
 class MIMENilAccept(NilAccept):
+    """
+    Represents an ``Accept`` header when it is not present in the request or is
+    empty.
+    """
     MasterClass = MIMEAccept
 
 def _check_offer(offer):


### PR DESCRIPTION
This is far from complete as documentation for the acceptparse.py classes, but as a lot may change in the near future, this pull request is mainly to set out the classes that need to be documented &mdash; I'll be changing and adding to this over the summer.

I added a comment about running into bugs with `:members` and `:inherited-members`, so that we remember why we chose to use `automethod` and `autoattribute` instead; and gave the comment a date so we can come back to it at a later date perhaps to check if the bugs have been fixed. Hope that's okay.