### PR TITLE
Accept language wip

### DIFF
--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -27,7 +27,6 @@ Accept-*
 .. autofunction:: create_accept_language_header
 
 .. autoclass:: AcceptLanguage
-   :members:
 
 .. autoclass:: AcceptLanguageValidHeader
    :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -19,6 +19,7 @@ Accept-*
 .. autofunction:: create_accept_language_header
 
 .. autoclass:: AcceptLanguage
+   :members: parse
 
 .. autoclass:: AcceptLanguageValidHeader
    :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
@@ -27,11 +28,13 @@ Accept-*
 
 .. autoclass:: AcceptLanguageNoHeader
    :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
-	     __radd__, __str__, basic_filtering, best_match, lookup, quality
+	     __radd__, __str__, parse, basic_filtering, best_match, lookup,
+             quality
 
 .. autoclass:: AcceptLanguageInvalidHeader
    :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
-	     __radd__, __str__, basic_filtering, best_match, lookup, quality
+	     __radd__, __str__, parse, basic_filtering, best_match, lookup,
+             quality
 
 .. autoclass:: MIMEAccept
    :members:

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -31,8 +31,8 @@ Accept-*
    :inherited-members:
 
 .. autoclass:: AcceptLanguageValidHeader
-   :members: __init__, __contains__, __iter__, parse, basic_filtering,
-             best_match, lookup, quality
+   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
+             parse, basic_filtering, best_match, lookup, quality
 
    .. autoinstanceattribute:: header_value
       :annotation:
@@ -40,7 +40,8 @@ Accept-*
       :annotation:
 
 .. autoclass:: AcceptLanguageNoHeader
-   :members: __init__
+   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
+             basic_filtering, best_match, lookup, quality
 
    .. autoinstanceattribute:: header_value
       :annotation:
@@ -48,7 +49,8 @@ Accept-*
       :annotation:
 
 .. autoclass:: AcceptLanguageInvalidHeader
-   :members: __init__
+   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
+             basic_filtering, best_match, lookup, quality
 
    .. autoinstanceattribute:: header_value
       :annotation:

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -6,14 +6,6 @@ Headers
 
 Accept-*
 ~~~~~~~~
-
-.. # We use ``autoinstanceattribute`` instead of  ``members`` to document
-   # instance attributes for now, because of
-   # https://github.com/sphinx-doc/sphinx/issues/904
-   # (``autoattribute`` and ``autodata`` do not work with instance attributes.)
-   # As mentioned there, ``autoinstanceattribute`` is undocumented. However, it
-   # has been around for years, and works.
-
 .. automodule:: webob.acceptparse
 
 .. autoclass:: AcceptCharset

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -28,7 +28,6 @@ Accept-*
 
 .. autoclass:: AcceptLanguage
    :members:
-   :inherited-members:
 
 .. autoclass:: AcceptLanguageValidHeader
    :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -24,6 +24,8 @@ Accept-*
    :members:
    :inherited-members:
 
+.. autofunction:: create_accept_language_header
+
 .. autoclass:: AcceptLanguage
    :members:
    :inherited-members:

--- a/docs/api/webob.txt
+++ b/docs/api/webob.txt
@@ -29,31 +29,17 @@ Accept-*
 .. autoclass:: AcceptLanguage
 
 .. autoclass:: AcceptLanguageValidHeader
-   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
-             parse, basic_filtering, best_match, lookup, quality
-
-   .. autoinstanceattribute:: header_value
-      :annotation:
-   .. autoinstanceattribute:: parsed
-      :annotation:
+   :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
+	     __radd__, __str__, parse, basic_filtering, best_match, lookup,
+             quality
 
 .. autoclass:: AcceptLanguageNoHeader
-   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
-             basic_filtering, best_match, lookup, quality
-
-   .. autoinstanceattribute:: header_value
-      :annotation:
-   .. autoinstanceattribute:: parsed
-      :annotation:
+   :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
+	     __radd__, __str__, basic_filtering, best_match, lookup, quality
 
 .. autoclass:: AcceptLanguageInvalidHeader
-   :members: __init__, __add__, __contains__, __iter__, __radd__, __str__,
-             basic_filtering, best_match, lookup, quality
-
-   .. autoinstanceattribute:: header_value
-      :annotation:
-   .. autoinstanceattribute:: parsed
-      :annotation:
+   :members: header_value, parsed, __init__, __add__, __contains__, __iter__,
+	     __radd__, __str__, basic_filtering, best_match, lookup, quality
 
 .. autoclass:: MIMEAccept
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,8 @@ todo_include_todos = False
 
 modindex_common_prefix = ['webob.']
 
+autodoc_member_order = 'bysource'
+
 # -- Options for HTML output ---------------------------------------------
 
 html_theme = 'alabaster'

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -613,8 +613,8 @@ class AcceptLanguageValidHeader(AcceptLanguage):
 
         .. warning::
 
-           This is maintained for backward compatibility, and may be deprecated
-           in the future.
+           This is maintained for backward compatibility, and will be
+           deprecated in the future.
 
         This method was WebOb's old criteron for deciding whether a language
         tag matches a language range, used in

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -32,6 +32,17 @@ qvalue_re = r"""
 weight_re = r'[ \t]*;[ \t]*[qQ]=(' + qvalue_re + r')'
 
 
+def _item_qvalue_pair_to_header_element(pair):
+    item, qvalue = pair
+    if qvalue == 1.0:
+        element = item
+    elif qvalue == 0.0:
+        element = '{};q=0'.format(item)
+    else:
+        element = '{};q={}'.format(item, qvalue)
+    return element
+
+
 class Accept(object):
     """
     Represents a generic ``Accept-*`` style header.
@@ -468,16 +479,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         jp;q=0.21'``.
 
         """
-        result = []
-        for range_, qvalue in self.parsed:
-            if qvalue == 1.0:
-                item = range_
-            elif qvalue == 0.0:
-                item = '{};q=0'.format(range_)
-            else:
-                item = '{};q={}'.format(range_, qvalue)
-            result.append(item)
-        return ', '.join(result)
+        return ', '.join(
+            _item_qvalue_pair_to_header_element(pair=tuple_)
+            for tuple_ in self.parsed
+        )
 
     def _old_match(self, mask, item):
         """

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -342,9 +342,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
                             ``Accept-Language`` header.
         """
         self._header_value = header_value
-
         self._parsed = list(self.parse(header_value))
-
         self._parsed_nonzero = [(m, q) for (m, q) in self.parsed if q]
 
     @property
@@ -1581,9 +1579,7 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
         Create an :class:`AcceptLanguageNoHeader` instance.
         """
         self._header_value = None
-
         self._parsed = None
-
         self._parsed_nonzero = None
 
     @property
@@ -1709,9 +1705,7 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         Create an :class:`AcceptLanguageInvalidHeader` instance.
         """
         self._header_value = header_value
-
         self._parsed = None
-
         self._parsed_nonzero = None
 
     @property

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1542,6 +1542,7 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
     addition operators (``+`` and ``+=``), which return a new object (see the
     docstring for :meth:`AcceptLanguageNoHeader.__add__`).
     """
+
     def __init__(self):
         """
         Create an :class:`AcceptLanguageNoHeader` instance.
@@ -1655,6 +1656,7 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
     addition operators (``+`` and ``+=``), which return a new object (see the
     docstring for :meth:`AcceptLanguageInvalidHeader.__add__`).
     """
+
     def __init__(self, header_value):
         """
         Create an :class:`AcceptLanguageInvalidHeader` instance.

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -304,6 +304,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
     7231, section 5.3.5 <7231#section-5.3.5>` to :rfc:`RFC 4647, section 2.1
     <4647#section-2.1>` to mean that only basic language ranges (and not
     extended language ranges) are expected in the ``Accept-Language`` header.
+
+    This object should not be modified. To add to the header, we can use the
+    addition operators (``+`` and ``+=``), which return a new object (see the
+    docstring for :meth:`AcceptLanguageValidHeader.__add__`).
     """
 
     # RFC 7231 Section 5.3.5 "Accept-Language":
@@ -378,6 +382,45 @@ class AcceptLanguageValidHeader(AcceptLanguage):
                     qvalue = float(qvalue) if qvalue else 1.0
                     yield (lang_range, qvalue)
             return generator(value=value)
+
+    def __add__(self, other):
+        """
+        Add to header, creating a new header object.
+
+        `other` can be:
+
+        * a ``str``
+        * a ``dict``, with language ranges as keys and qvalues as values
+        * a ``tuple`` or ``list``, of language range ``str``s or of ``tuple``
+          or ``list`` (language range, qvalue) pairs (``str``s and pairs can be
+          mixed within the ``tuple`` or ``list``)
+        * any object that returns a value for `__str__`
+        * an :class:`AcceptLanguageValidHeader`,
+          :class:`AcceptLanguageNoHeader`, or
+          :class:`AcceptLanguageInvalidHeader` instance
+
+        If neither operands are empty (header value ``''``) or
+        ``None``/:class:`AcceptLanguageNoHeader`, the two header values are
+        joined with ``', '``.
+        """
+        if isinstance(other, AcceptLanguageNoHeader):
+            return self.__class__(header_value=self.header_value)
+
+        if isinstance(other, AcceptLanguageValidHeader):
+            return create_accept_language_header(
+                header_value=self.header_value + ', ' + other.header_value,
+            )
+
+        if isinstance(other, AcceptLanguageInvalidHeader):
+            if other.header_value == '':
+                return self.__class__(header_value=self.header_value)
+            return create_accept_language_header(
+                header_value=self.header_value + ', ' + other.header_value,
+            )
+
+        return self._add_instance_and_non_accept_language_type(
+            instance=self, other=other,
+        )
 
     def __nonzero__(self):
         """
@@ -463,6 +506,16 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         ):
             yield m
 
+    def __radd__(self, other):
+        """
+        Add to header, creating a new header object.
+
+        See the docstring for :meth:`AcceptLanguageValidHeader.__add__`.
+        """
+        return self._add_instance_and_non_accept_language_type(
+            instance=self, other=other, instance_on_the_right=True,
+        )
+
     def __repr__(self):
         return "{}(header_value={!r})".format(
             # ``!r`` escapes the header value
@@ -483,6 +536,43 @@ class AcceptLanguageValidHeader(AcceptLanguage):
             _item_qvalue_pair_to_header_element(pair=tuple_)
             for tuple_ in self.parsed
         )
+
+    def _add_instance_and_non_accept_language_type(
+        self, instance, other, instance_on_the_right=False,
+    ):
+        if not other:
+            return self.__class__(header_value=instance.header_value)
+
+        if isinstance(other, str):
+            other_header_value = other
+        else:
+            if hasattr(other, 'items'):
+                other = sorted(
+                    other.items(),
+                    key=lambda item: item[1],
+                    reverse=True,
+                )
+            if isinstance(other, (tuple, list)):
+                result = []
+                for element in other:
+                    if isinstance(element, (tuple, list)):
+                        element = _item_qvalue_pair_to_header_element(
+                            pair=element
+                        )
+                    result.append(element)
+                other_header_value = ', '.join(result)
+            else:
+                other_header_value = str(other)
+                if other_header_value == '':
+                    return self.__class__(header_value=instance.header_value)
+
+        new_header_value = (
+            (other_header_value + ', ' + instance.header_value)
+            if instance_on_the_right
+            else (instance.header_value + ', ' + other_header_value)
+        )
+
+        return create_accept_language_header(header_value=new_header_value)
 
     def _old_match(self, mask, item):
         """

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -535,17 +535,12 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         )
 
     def __repr__(self):
-        return "<{} header_value={!r}>".format(
-            # We use angle brackets to indicate that it is not in eval()-able
-            # form. The header_value is untrusted input; there could be a
-            # mistake in the validating regex or elsewhere, and it is not worth
-            # the risk.
-            # ``!r`` escapes the header value and places it inside quotes
-            # There should be no escaping involved, given that the header value
-            # has been validated by the regex, but just in case.
-            self.__class__.__name__,
-            self.header_value,
-        )
+        return "<{}>".format(self.__class__.__name__)
+        # We use angle brackets to indicate that it is not in eval()-able form.
+        # We do not display the header_value, as it is untrusted input; there
+        # could be a mistake in the validating regex or elsewhere. The
+        # header_value could always be easily obtained from the .header_value
+        # property.
 
     def __str__(self):
         r"""

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -378,9 +378,9 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         Parse an ``Accept-Language`` header.
 
         :param value: (``str``) header value
-        :return: If `value` is a valid ``Accept-Language`` header, returns a
-                 generator iterator that yields (language range, quality value)
-                 tuples, as parsed from the header from left to right.
+        :return: If `value` is a valid ``Accept-Language`` header, returns an
+                 iterator of (language range, quality value) tuples, as parsed
+                 from the header from left to right.
         :raises ValueError: if `value` is an invalid header
         """
         # Check if header is valid

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1119,8 +1119,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
           not already matched by other ranges within the header are
           unacceptable.
         """
-        assert not (default_tag is None and default is None), \
-            '`default_tag` and `default` arguments cannot both be None.'
+        if default_tag is None and default is None:
+            raise TypeError(
+                '`default_tag` and `default` arguments cannot both be None.'
+            )
 
         # We need separate `default_tag` and `default` arguments because if we
         # only had the `default` argument, there would be no way to tell
@@ -1128,7 +1130,8 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         # whether it has been specified as not acceptable with a q=0 range in
         # the header) or not (in which case we can just return the value).
 
-        assert default_range != '*', 'default_range cannot be *.'
+        if default_range == '*':
+            raise ValueError('default_range cannot be *.')
 
         parsed = list(self.parsed)
 
@@ -1538,8 +1541,10 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
 
                  | the return value from `default_tag` or `default`.
         """
-        assert not (default_tag is None and default is None), \
-            '`default_tag` and `default` arguments cannot both be None.'
+        if default_tag is None and default is None:
+            raise TypeError(
+                '`default_tag` and `default` arguments cannot both be None.'
+            )
 
         if default_tag is not None:
             return default_tag

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -67,8 +67,6 @@ class Accept(object):
         """
         for match in part_re.finditer(','+value):
             name = match.group(1)
-            if name == 'q':
-                continue
             quality = match.group(2) or ''
             if quality:
                 try:

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -21,16 +21,21 @@ from webob.util import (
 part_re = re.compile(
     r',\s*([^\s;,\n]+)(?:[^,]*?;\s*q=([0-9.]*))?')
 
+# RFC 7230 Section 3.2.3 "Whitespace"
+# OWS            = *( SP / HTAB )
+#                ; optional whitespace
+OWS_re = '[ \t]*'
+
 # RFC 7231 Section 5.3.1 "Quality Values"
 # qvalue = ( "0" [ "." 0*3DIGIT ] )
 #        / ( "1" [ "." 0*3("0") ] )
-qvalue_re = r"""
-    (?:0(?:\.[0-9]{0,3})?)
-    |
-    (?:1(?:\.0{0,3})?)
-    """
+qvalue_re = (
+    r'(?:0(?:\.[0-9]{0,3})?)'
+    '|'
+    r'(?:1(?:\.0{0,3})?)'
+)
 # weight = OWS ";" OWS "q=" qvalue
-weight_re = r'[ \t]*;[ \t]*[qQ]=(' + qvalue_re + r')'
+weight_re = OWS_re + ';' + OWS_re + '[qQ]=(' + qvalue_re + ')'
 
 
 def _item_n_weight_re(item_re):
@@ -53,9 +58,8 @@ def _list_1_or_more__compiled_re(element_re):
     # 1#element => *( "," OWS ) element *( OWS "," [ OWS element ] )
     # and RFC 7230 Errata ID: 4169
     return re.compile(
-        r'^(?:,[ \t]*)*' + element_re +
-        r'(?:[ \t]*,(?:[ \t]*' + element_re + r')?)*$',
-        re.VERBOSE
+        '^(?:,' + OWS_re + ')*' + element_re +
+        '(?:' + OWS_re + ',(?:' + OWS_re + element_re + ')?)*$',
     )
 
 
@@ -351,18 +355,15 @@ class AcceptLanguageValidHeader(AcceptLanguage):
     # RFC 4647 Section 2.1 "Basic Language Range":
     # language-range   = (1*8ALPHA *("-" 1*8alphanum)) / "*"
     # alphanum         = ALPHA / DIGIT
-    lang_range_re = r"""
-        \*|
-        (?:
-        [A-Za-z]{1,8}
-        (?:-[A-Za-z0-9]{1,8})*
-        )
-    """
-    lang_range_n_weight_re = _item_n_weight_re(item_re=lang_range_re)
-    lang_range_n_weight_compiled_re = re.compile(
-        lang_range_n_weight_re,
-        re.VERBOSE
+    lang_range_re = (
+        r'\*|'
+        '(?:'
+        '[A-Za-z]{1,8}'
+        '(?:-[A-Za-z0-9]{1,8})*'
+        ')'
     )
+    lang_range_n_weight_re = _item_n_weight_re(item_re=lang_range_re)
+    lang_range_n_weight_compiled_re = re.compile(lang_range_n_weight_re)
     accept_language_compiled_re = _list_1_or_more__compiled_re(
         element_re=lang_range_n_weight_re,
     )

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -307,7 +307,7 @@ class AcceptLanguage(object):
     """
 
     @classmethod
-    def python_value_to_header_str(cls, value):
+    def _python_value_to_header_str(cls, value):
         if isinstance(value, str):
             header_str = value
         else:
@@ -594,7 +594,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         if not other:
             return self.__class__(header_value=instance.header_value)
 
-        other_header_value = self.python_value_to_header_str(value=other)
+        other_header_value = self._python_value_to_header_str(value=other)
 
         try:
             self.parse(value=other_header_value)
@@ -1669,7 +1669,7 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
         if not other:
             return self.__class__()
 
-        other_header_value = self.python_value_to_header_str(value=other)
+        other_header_value = self._python_value_to_header_str(value=other)
 
         try:
             return AcceptLanguageValidHeader(header_value=other_header_value)
@@ -1781,7 +1781,7 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         if not other:
             return AcceptLanguageNoHeader()
 
-        other_header_value = self.python_value_to_header_str(value=other)
+        other_header_value = self._python_value_to_header_str(value=other)
 
         try:
             return AcceptLanguageValidHeader(header_value=other_header_value)
@@ -1856,7 +1856,7 @@ def accept_language_property():
             ):
                 header_value = value.header_value
             else:
-                header_value = AcceptLanguage.python_value_to_header_str(
+                header_value = AcceptLanguage._python_value_to_header_str(
                     value=value,
                 )
             request.environ[ENVIRON_KEY] = header_value

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1609,6 +1609,7 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
         return '{}()'.format(self.__class__.__name__)
 
     def __str__(self):
+        """Return the ``str`` ``'<no header in request>'``."""
         return '<no header in request>'
 
     def _add_instance_and_non_accept_language_type(self, instance, other):
@@ -1736,6 +1737,7 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         )
 
     def __str__(self):
+        """Return the ``str`` ``'<invalid header value>'``."""
         return '<invalid header value>'
 
     def _add_instance_and_non_accept_language_type(

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -491,7 +491,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         other problems with the old criterion for a match.)
         """
         warnings.warn(
-            'The behavior of AcceptLanguageValidHeader.__contains__ is'
+            'The behavior of AcceptLanguageValidHeader.__contains__ is '
             'currently being maintained for backward compatibility, but it may'
             ' change in the future to better conform to the RFC.',
             PendingDeprecationWarning,
@@ -1359,7 +1359,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         and this always returns ``True``.
         """
         warnings.warn(
-            'The behavior of .__contains__ for the AcceptLanguage classes is'
+            'The behavior of .__contains__ for the AcceptLanguage classes is '
             'currently being maintained for backward compatibility, but it may'
             ' change in the future to better conform to the RFC.',
             PendingDeprecationWarning,

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1870,11 +1870,7 @@ def accept_language_property():
     ENVIRON_KEY = 'HTTP_ACCEPT_LANGUAGE'
 
     def fget(request):
-        """
-        Get an object representing the header in the request.
-
-        This creates a new object (and re-parses the header) on every call.
-        """
+        """Get an object representing the header in the request."""
         return create_accept_language_header(
             header_value=request.environ.get(ENVIRON_KEY)
         )

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1783,11 +1783,9 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         )
 
     def __repr__(self):
-        return "{}(header_value={!r})".format(
-            # ``!r`` escapes the header value
-            self.__class__.__name__,
-            self.header_value,
-        )
+        # The header value is untrusted input, so if it is not valid, we will
+        # not risk returning it in an eval()-able form
+        return '<AcceptLanguageInvalidHeader instance>'
 
     def __str__(self):
         """Return the ``str`` ``'<invalid header value>'``."""

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -535,8 +535,14 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         )
 
     def __repr__(self):
-        return "{}(header_value={!r})".format(
-            # ``!r`` escapes the header value
+        return "<{} header_value={!r}>".format(
+            # We use angle brackets to indicate that it is not in eval()-able
+            # form. The header_value is untrusted input; there could be a
+            # mistake in the validating regex or elsewhere, and it is not worth
+            # the risk.
+            # ``!r`` escapes the header value and places it inside quotes
+            # There should be no escaping involved, given that the header value
+            # has been validated by the regex, but just in case.
             self.__class__.__name__,
             self.header_value,
         )

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -688,14 +688,14 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         :rfc:`RFC 4647, section 3.3.1 <4647#section-3.3.1>`. It filters the
         tags in the `language_tags` argument and returns the ones that match
         the header according to the matching scheme. The returned list is a
-        list of (language tag, qvalue) tuples, in descending order of qvalue;
-        if two or more tags have the same qvalue, they are returned in the same
-        order as the order in the header of the ranges they matched. If the
-        matched range is the same for two or more tags (i.e. their matched
-        ranges have the same qvalue and the same position in the header), then
-        they are returned in the same order as their order in the
-        `language_tags` argument. (If `language_tags` is unordered, e.g. if it
-        is a set or a dict, then that order may not be reliable.)
+        list of (language tag, qvalue) tuples, in descending order of qvalue.
+        If two or more tags have the same qvalue, they are returned in the same
+        order as that in the header of the ranges they matched. If the matched
+        range is the same for two or more tags (i.e. their matched ranges have
+        the same qvalue and the same position in the header), then they are
+        returned in the same order as that in the `language_tags` argument. If
+        `language_tags` is unordered, e.g. if it is a set or a dict, then that
+        order may not be reliable.
 
         :param language_tags: (``iterable``) language tags
         :return: A list of tuples of the form (language tag, qvalue), in
@@ -716,9 +716,9 @@ class AcceptLanguageValidHeader(AcceptLanguage):
            following the prefix is "-".' (:rfc:`RFC 4647, section 3.3.1
            <4647#section-3.3.1>`)
         4. If a language tag has not matched any of the language ranges so far,
-           and there is one or more ``*`` language range in the header, then:
-           if any of the ``*`` language ranges have ``q=0``, the language tag
-           is filtered out. Otherwise, the language tag is considered a match.
+           and there is one or more ``*`` language range in the header, then if
+           any of the ``*`` language ranges have ``q=0``, the language tag is
+           filtered out, else the language tag is considered a match.
         """
         # The Basic Filtering matching scheme as applied to the Accept-Language
         # header is very under-specified by RFCs 7231 and 4647. This

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -452,6 +452,13 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         ):
             yield m
 
+    def __repr__(self):
+        return "{}(header_value={!r})".format(
+            # ``!r`` escapes the header value
+            self.__class__.__name__,
+            self.header_value,
+        )
+
     def _old_match(self, mask, item):
         """
         Return whether a language tag matches a language range.
@@ -1435,6 +1442,9 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
 
         self._parsed_nonzero = None
 
+    def __repr__(self):
+        return '{}()'.format(self.__class__.__name__)
+
 
 class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
     """
@@ -1461,6 +1471,15 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         cannot be parsed, this is ``None``."""
 
         self._parsed_nonzero = None
+
+    def __repr__(self):
+        return "{}(header_value={!r})".format(
+            # ``!r`` escapes the header value
+            self.__class__.__name__,
+            self.header_value,
+        )
+
+
 class MIMEAccept(Accept):
     """
     Represents an ``Accept`` header, which is a list of mimetypes.

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -376,8 +376,8 @@ class AcceptLanguageValidHeader(AcceptLanguage):
 
         :param value: (``str``) header value
         :return: If `value` is a valid ``Accept-Language`` header, returns a
-                 generator that yields (language range, quality value) tuples,
-                 as parsed from the header from left to right.
+                 generator iterator that yields (language range, quality value)
+                 tuples, as parsed from the header from left to right.
         :raises ValueError: if `value` is an invalid header
         """
         # Check if header is valid

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -521,7 +521,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         )
 
     def __str__(self):
-        """
+        r"""
         Return a tidied up version of the header value.
 
         e.g. If the ``header_value`` is ``', \t,de;q=0.000 \t, es;q=1.000, zh,

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -241,7 +241,7 @@ class NilAccept(object):
         _check_offer(item)
         return True
 
-    def quality(self, offer, default_quality=1):
+    def quality(self, offer):
         return 0
 
     def best_match(self, offers, default_match=None):

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1300,8 +1300,6 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
     have much behaviour in common.
     """
 
-    HeaderClass = AcceptLanguage
-
     def __nonzero__(self):
         """
         Return whether ``self`` represents a valid ``Accept-Language`` header.

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -616,7 +616,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
            This is maintained for backward compatibility, and will be
            deprecated in the future.
 
-        This method was WebOb's old criteron for deciding whether a language
+        This method was WebOb's old criterion for deciding whether a language
         tag matches a language range, used in
 
         - :meth:`AcceptLanguageValidHeader.__contains__`

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -459,6 +459,26 @@ class AcceptLanguageValidHeader(AcceptLanguage):
             self.header_value,
         )
 
+    def __str__(self):
+        """
+        Return a tidied up version of the header value.
+
+        e.g. If the ``header_value`` is ``', \t,de;q=0.000 \t, es;q=1.000, zh,
+        jp;q=0.210  ,'``, ``str(instance)`` returns ``'de;q=0, es, zh,
+        jp;q=0.21'``.
+
+        """
+        result = []
+        for range_, qvalue in self.parsed:
+            if qvalue == 1.0:
+                item = range_
+            elif qvalue == 0.0:
+                item = '{};q=0'.format(range_)
+            else:
+                item = '{};q={}'.format(range_, qvalue)
+            result.append(item)
+        return ', '.join(result)
+
     def _old_match(self, mask, item):
         """
         Return whether a language tag matches a language range.
@@ -1445,6 +1465,9 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
     def __repr__(self):
         return '{}()'.format(self.__class__.__name__)
 
+    def __str__(self):
+        return '<no header in request>'
+
 
 class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
     """
@@ -1478,6 +1501,9 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
             self.__class__.__name__,
             self.header_value,
         )
+
+    def __str__(self):
+        return '<invalid header value>'
 
 
 class MIMEAccept(Accept):

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -388,7 +388,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         # the match *and* get all the groups using the same regex, so we have
         # to use one regex to check the match, and another to get the groups.
         if cls.accept_language_compiled_re.match(value) is None:
-            raise ValueError  # invalid header
+            raise ValueError('Invalid value for an Accept-Language header.')
         def generator(value):
             for match in (
                 cls.lang_range_n_weight_compiled_re.finditer(value)

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -386,16 +386,15 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         # to use one regex to check the match, and another to get the groups.
         if cls.accept_language_compiled_re.match(value) is None:
             raise ValueError  # invalid header
-        else:
-            def generator(value):
-                for match in (
-                    cls.lang_range_n_weight_compiled_re.finditer(value)
-                ):
-                    lang_range = match.group(1)
-                    qvalue = match.group(2)
-                    qvalue = float(qvalue) if qvalue else 1.0
-                    yield (lang_range, qvalue)
-            return generator(value=value)
+        def generator(value):
+            for match in (
+                cls.lang_range_n_weight_compiled_re.finditer(value)
+            ):
+                lang_range = match.group(1)
+                qvalue = match.group(2)
+                qvalue = float(qvalue) if qvalue else 1.0
+                yield (lang_range, qvalue)
+        return generator(value=value)
 
     def __add__(self, other):
         """

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -535,7 +535,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         )
 
     def __repr__(self):
-        return "<{}>".format(self.__class__.__name__)
+        return '<{}>'.format(self.__class__.__name__)
         # We use angle brackets to indicate that it is not in eval()-able form.
         # We do not display the header_value, as it is untrusted input; there
         # could be a mistake in the validating regex or elsewhere. The

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -440,7 +440,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
 
            The behavior of :meth:`AcceptLanguageValidHeader.__contains__` is
            currently being maintained for backward compatibility, but it may
-           change in future to better conform to the RFC.
+           change in the future to better conform to the RFC.
 
            What is 'acceptable' depends on the needs of your application.
            :rfc:`RFC 7231, section 5.3.5 <7231#section-5.3.5>` suggests three
@@ -474,7 +474,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.__contains__ is'
             'currently being maintained for backward compatibility, but it may'
-            ' change in future to better conform to the RFC.',
+            ' change in the future to better conform to the RFC.',
             PendingDeprecationWarning,
         )
         for mask, quality in self._parsed_nonzero:
@@ -590,7 +590,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         .. warning::
 
            This is maintained for backward compatibility, and may be deprecated
-           in future.
+           in the future.
 
         This method was WebOb's old criteron for deciding whether a language
         tag matches a language range, used in
@@ -825,7 +825,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         .. warning::
 
            This is currently maintained for backward compatibility, and may be
-           deprecated in future.
+           deprecated in the future.
 
            :meth:`AcceptLanguageValidHeader.best_match` uses its own algorithm
            (one not specified in :rfc:`RFC 7231 <7231>`) to determine what is a
@@ -920,7 +920,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.best_match is '
             'currently being maintained for backward compatibility, but it may'
-            ' be deprecated in future as it does not conform to the RFC.',
+            ' be deprecated in the future as it does not conform to the RFC.',
             PendingDeprecationWarning,
         )
         best_quality = -1
@@ -1207,7 +1207,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         .. warning::
 
            This is currently maintained for backward compatibility, and may be
-           deprecated in future.
+           deprecated in the future.
 
            :meth:`AcceptLanguageValidHeader.quality` uses its own algorithm
            (one not specified in :rfc:`RFC 7231 <7231>`) to determine what is a
@@ -1271,7 +1271,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.quality is'
             'currently being maintained for backward compatibility, but it may'
-            ' be deprecated in future as it does not conform to the RFC.',
+            ' be deprecated in the future as it does not conform to the RFC.',
             PendingDeprecationWarning,
         )
         # [If ``modifier`` is positive, it would not change the result of the
@@ -1333,7 +1333,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
 
            The behavior of ``.__contains__`` for the ``AcceptLanguage`` classes
            is currently being maintained for backward compatibility, but it may
-           change in future to better conform to the RFC.
+           change in the future to better conform to the RFC.
 
         :param offer: (``str``) language tag offer
         :return: (``bool``) Whether ``offer`` is acceptable according to the
@@ -1346,7 +1346,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of .__contains__ for the AcceptLanguage classes is'
             'currently being maintained for backward compatibility, but it may'
-            ' change in future to better conform to the RFC.',
+            ' change in the future to better conform to the RFC.',
             PendingDeprecationWarning,
         )
         return True
@@ -1401,7 +1401,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         .. warning::
 
            This is currently maintained for backward compatibility, and may be
-           deprecated in future (see the documentation for
+           deprecated in the future (see the documentation for
            :meth:`AcceptLanguageValidHeader.best_match`).
 
         When the header is invalid, or there is no `Accept-Language` header in
@@ -1433,7 +1433,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of .best_match for the AcceptLanguage classes is '
             'currently being maintained for backward compatibility, but the '
-            'method may be deprecated in future, as its behavior is not '
+            'method may be deprecated in the future, as its behavior is not '
             'specified in (and currently does not conform to) RFC 7231.',
             PendingDeprecationWarning,
         )
@@ -1538,7 +1538,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         .. warning::
 
            This is currently maintained for backward compatibility, and may be
-           deprecated in future (see the documentation for
+           deprecated in the future (see the documentation for
            :meth:`AcceptLanguageValidHeader.quality`).
 
         :param offer: (``str``) language tag offer
@@ -1550,7 +1550,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of .quality for the AcceptLanguage classes is '
             'currently being maintained for backward compatibility, but the '
-            'method may be deprecated in future, as its behavior is not '
+            'method may be deprecated in the future, as its behavior is not '
             'specified in (and currently does not conform to) RFC 7231.',
             PendingDeprecationWarning,
         )

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -341,14 +341,25 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         :raises ValueError: if `header_value` is an invalid value for an
                             ``Accept-Language`` header.
         """
-        self.header_value = header_value
-        """(``str``) The header value."""
+        self._header_value = header_value
 
-        self.parsed = list(self.parse(header_value))
-        """(``list``) Parsed form of the header: a list of (language range,
-        quality value) tuples."""
+        self._parsed = list(self.parse(header_value))
 
         self._parsed_nonzero = [(m, q) for (m, q) in self.parsed if q]
+
+    @property
+    def header_value(self):
+        """(``str``) The header value."""
+        return self._header_value
+
+    @property
+    def parsed(self):
+        """
+        (``list``) Parsed form of the header.
+
+        A list of (language range, quality value) tuples.
+        """
+        return self._parsed
 
     @classmethod
     def parse(cls, value):
@@ -1568,15 +1579,29 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
         """
         Create an :class:`AcceptLanguageNoHeader` instance.
         """
-        self.header_value = None
-        """(``str``) The header value. As there is no header in the request,
-        this is ``None``."""
+        self._header_value = None
 
-        self.parsed = None
-        """(``list``) Parsed form of the header. As there is no header in the
-        request, this is ``None``."""
+        self._parsed = None
 
         self._parsed_nonzero = None
+
+    @property
+    def header_value(self):
+        """
+        (``str``) The header value.
+
+        As there is no header in the request, this is ``None``.
+        """
+        return self._header_value
+
+    @property
+    def parsed(self):
+        """
+        (``list``) Parsed form of the header.
+
+        As there is no header in the request, this is ``None``.
+        """
+        return self._parsed
 
     def __add__(self, other):
         """
@@ -1682,14 +1707,25 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         """
         Create an :class:`AcceptLanguageInvalidHeader` instance.
         """
-        self.header_value = header_value
-        """(``str``) The header value."""
+        self._header_value = header_value
 
-        self.parsed = None
-        """(``list``) Parsed form of the header. As the header is invalid and
-        cannot be parsed, this is ``None``."""
+        self._parsed = None
 
         self._parsed_nonzero = None
+
+    @property
+    def header_value(self):
+        """(``str``) The header value."""
+        return self._header_value
+
+    @property
+    def parsed(self):
+        """
+        (``list``) Parsed form of the header.
+
+        As the header is invalid and cannot be parsed, this is ``None``.
+        """
+        return self._parsed
 
     def __add__(self, other):
         """

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1676,9 +1676,9 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
     invalid ``Accept-Language`` header.
 
     :rfc:`7231` does not provide any guidance on what should happen if the
-    ``Accept-Language`` has an invalid value. This implementation disregards
-    the header, and treats it as if there is no ``Accept-Language`` header in
-    the request.
+    ``Accept-Language`` header has an invalid value. This implementation
+    disregards the header, and treats it as if there is no ``Accept-Language``
+    header in the request.
 
     This object should not be modified. To add to the header, we can use the
     addition operators (``+`` and ``+=``), which return a new object (see the

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -154,7 +154,7 @@ class Accept(object):
             if self._match(mask, offer):
                 return True
 
-    def quality(self, offer, modifier=1):
+    def quality(self, offer):
         """
         Return the quality of the given offer.  Returns None if there
         is no match (not 0).
@@ -162,7 +162,7 @@ class Accept(object):
         bestq = 0
         for mask, q in self.parsed:
             if self._match(mask, offer):
-                bestq = max(bestq, q * modifier)
+                bestq = max(bestq, q)
         return bestq or None
 
     def best_match(self, offers, default_match=None):
@@ -1224,7 +1224,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         except TypeError:  # default is not a callable
             return default
 
-    def quality(self, offer, modifier=1):
+    def quality(self, offer):
         """
         Return quality value of given offer, or ``None`` if there is no match.
 
@@ -1299,26 +1299,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
             'RFC.',
             DeprecationWarning,
         )
-        # [If ``modifier`` is positive, it would not change the result of the
-        # comparison using ``max()`` (apart from the first comparison with
-        # bestq, when it is 0), because all the ``q``s are multiplied by the
-        # same modifier. So in effect, it is just multiplying the highest
-        # quality value by the ``modifier``.
-        #
-        # If ``modifier`` is negative, bestq would always be 0, because it
-        # starts off as 0, and max(0, negative number) is always 0. So the
-        # method would always return None.
-        #
-        # If ``modifier`` is 0, bestq would always be 0, so the method would
-        # always return None.
-        #
-        # There was no explanation of the parameter in the existing
-        # documentation, and it is unclear what it was intended to do, so I
-        # have left it undocumented for now.]
         bestq = 0
         for mask, q in self.parsed:
             if self._old_match(mask, offer):
-                bestq = max(bestq, q * modifier)
+                bestq = max(bestq, q)
         return bestq or None
 
 

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -485,7 +485,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         .. warning::
 
            The behavior of :meth:`AcceptLanguageValidHeader.__contains__` is
-           currently being maintained for backward compatibility, but it may
+           currently being maintained for backward compatibility, but it will
            change in the future to better conform to the RFC.
 
            What is 'acceptable' depends on the needs of your application.
@@ -519,9 +519,9 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.__contains__ is '
-            'currently being maintained for backward compatibility, but it may'
-            ' change in the future to better conform to the RFC.',
-            PendingDeprecationWarning,
+            'currently being maintained for backward compatibility, but it '
+            'will change in the future to better conform to the RFC.',
+            DeprecationWarning,
         )
         for mask, quality in self._parsed_nonzero:
             if self._old_match(mask, offer):
@@ -535,7 +535,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         .. warning::
 
            The behavior of this method is currently maintained for backward
-           compatibility, but may change in the future.
+           compatibility, but will change in the future.
 
         :return: iterator of all the language ranges in the header with non-0
                  qvalues, in descending order of qvalue. If two ranges have the
@@ -549,9 +549,9 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.__iter__ is currently '
-            'maintained for backward compatibility, but may change in the '
+            'maintained for backward compatibility, but will change in the '
             'future.',
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
 
         for m, q in sorted(
@@ -844,7 +844,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
 
         .. warning::
 
-           This is currently maintained for backward compatibility, and may be
+           This is currently maintained for backward compatibility, and will be
            deprecated in the future.
 
            :meth:`AcceptLanguageValidHeader.best_match` uses its own algorithm
@@ -939,9 +939,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.best_match is '
-            'currently being maintained for backward compatibility, but it may'
-            ' be deprecated in the future as it does not conform to the RFC.',
-            PendingDeprecationWarning,
+            'currently being maintained for backward compatibility, but it '
+            'will be deprecated in the future as it does not conform to the '
+            'RFC.',
+            DeprecationWarning,
         )
         best_quality = -1
         best_offer = default_match
@@ -1226,7 +1227,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
 
         .. warning::
 
-           This is currently maintained for backward compatibility, and may be
+           This is currently maintained for backward compatibility, and will be
            deprecated in the future.
 
            :meth:`AcceptLanguageValidHeader.quality` uses its own algorithm
@@ -1290,9 +1291,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.quality is'
-            'currently being maintained for backward compatibility, but it may'
-            ' be deprecated in the future as it does not conform to the RFC.',
-            PendingDeprecationWarning,
+            'currently being maintained for backward compatibility, but it '
+            'will be deprecated in the future as it does not conform to the '
+            'RFC.',
+            DeprecationWarning,
         )
         # [If ``modifier`` is positive, it would not change the result of the
         # comparison using ``max()`` (apart from the first comparison with
@@ -1352,8 +1354,8 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         .. warning::
 
            The behavior of ``.__contains__`` for the ``AcceptLanguage`` classes
-           is currently being maintained for backward compatibility, but it may
-           change in the future to better conform to the RFC.
+           is currently being maintained for backward compatibility, but it
+           will change in the future to better conform to the RFC.
 
         :param offer: (``str``) language tag offer
         :return: (``bool``) Whether ``offer`` is acceptable according to the
@@ -1365,9 +1367,9 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of .__contains__ for the AcceptLanguage classes is '
-            'currently being maintained for backward compatibility, but it may'
-            ' change in the future to better conform to the RFC.',
-            PendingDeprecationWarning,
+            'currently being maintained for backward compatibility, but it '
+            'will change in the future to better conform to the RFC.',
+            DeprecationWarning,
         )
         return True
 
@@ -1378,7 +1380,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         .. warning::
 
            The behavior of this method is currently maintained for backward
-           compatibility, but may change in the future.
+           compatibility, but will change in the future.
 
         :return: iterator of all the language ranges in the header with non-0
                  qvalues, in descending order of qvalue. If two ranges have the
@@ -1391,9 +1393,9 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         """
         warnings.warn(
             'The behavior of AcceptLanguageValidHeader.__iter__ is currently '
-            'maintained for backward compatibility, but may change in the '
+            'maintained for backward compatibility, but will change in the '
             'future.',
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         return iter(())
 
@@ -1420,7 +1422,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
 
         .. warning::
 
-           This is currently maintained for backward compatibility, and may be
+           This is currently maintained for backward compatibility, and will be
            deprecated in the future (see the documentation for
            :meth:`AcceptLanguageValidHeader.best_match`).
 
@@ -1453,9 +1455,9 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of .best_match for the AcceptLanguage classes is '
             'currently being maintained for backward compatibility, but the '
-            'method may be deprecated in the future, as its behavior is not '
+            'method will be deprecated in the future, as its behavior is not '
             'specified in (and currently does not conform to) RFC 7231.',
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         best_quality = -1
         best_offer = default_match
@@ -1557,7 +1559,7 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
 
         .. warning::
 
-           This is currently maintained for backward compatibility, and may be
+           This is currently maintained for backward compatibility, and will be
            deprecated in the future (see the documentation for
            :meth:`AcceptLanguageValidHeader.quality`).
 
@@ -1570,9 +1572,9 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         warnings.warn(
             'The behavior of .quality for the AcceptLanguage classes is '
             'currently being maintained for backward compatibility, but the '
-            'method may be deprecated in the future, as its behavior is not '
+            'method will be deprecated in the future, as its behavior is not '
             'specified in (and currently does not conform to) RFC 7231.',
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         return 1.0
 

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1506,6 +1506,29 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         return '<invalid header value>'
 
 
+
+def create_accept_language_header(header_value):
+    """
+    Create an object representing the ``Accept-Language`` header in a request.
+
+    :param header_value: (``str``) header value
+    :return: If `header_value` is ``None``, an :class:`AcceptLanguageNoHeader`
+             instance.
+
+             | If `header_value` is a valid ``Accept-Language`` header, an
+               :class:`AcceptLanguageValidHeader` instance.
+
+             | If `header_value` is an invalid ``Accept-Language`` header, an
+               :class:`AcceptLanguageInvalidHeader` instance.
+    """
+    if header_value is None:
+        return AcceptLanguageNoHeader()
+    try:
+        return AcceptLanguageValidHeader(header_value=header_value)
+    except ValueError:
+        return AcceptLanguageInvalidHeader(header_value=header_value)
+
+
 class MIMEAccept(Accept):
     """
     Represents an ``Accept`` header, which is a list of mimetypes.

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -486,6 +486,11 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         Return all the ranges with non-0 qvalues, in order of preference.
 
+        .. warning::
+
+           The behavior of this method is currently maintained for backward
+           compatibility, but may change in the future.
+
         :return: iterator of all the language ranges in the header with non-0
                  qvalues, in descending order of qvalue. If two ranges have the
                  same qvalue, they are returned in the order of their positions
@@ -496,6 +501,13 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         prefers, e.g. ``'en-gb;q=0, *'`` means 'everything but British
         English', but ``list(instance)`` would return only ``['*']``.
         """
+        warnings.warn(
+            'The behavior of AcceptLanguageValidHeader.__iter__ is currently '
+            'maintained for backward compatibility, but may change in the '
+            'future.',
+            PendingDeprecationWarning,
+        )
+
         for m, q in sorted(
             self._parsed_nonzero,
             key=lambda i: i[1],
@@ -1343,6 +1355,11 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         """
         Return all the ranges with non-0 qvalues, in order of preference.
 
+        .. warning::
+
+           The behavior of this method is currently maintained for backward
+           compatibility, but may change in the future.
+
         :return: iterator of all the language ranges in the header with non-0
                  qvalues, in descending order of qvalue. If two ranges have the
                  same qvalue, they are returned in the order of their positions
@@ -1352,6 +1369,12 @@ class _AcceptLanguageInvalidOrNoHeader(AcceptLanguage):
         request, or the header is invalid, so there are no language ranges, and
         this always returns an empty iterator.
         """
+        warnings.warn(
+            'The behavior of AcceptLanguageValidHeader.__iter__ is currently '
+            'maintained for backward compatibility, but may change in the '
+            'future.',
+            PendingDeprecationWarning,
+        )
         return iter(())
 
     def basic_filtering(self, language_tags):

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -581,7 +581,6 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         e.g. If the ``header_value`` is ``', \t,de;q=0.000 \t, es;q=1.000, zh,
         jp;q=0.210  ,'``, ``str(instance)`` returns ``'de;q=0, es, zh,
         jp;q=0.21'``.
-
         """
         return ', '.join(
             _item_qvalue_pair_to_header_element(pair=tuple_)

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -244,6 +244,7 @@ class NilAccept(object):
                 best_quality = quality
         return best_offer
 
+
 class NoAccept(NilAccept):
     """
     Represents an ``Accept-Encoding`` header when it is not present in the

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -281,18 +281,13 @@ class AcceptEncoding(Accept):
     """
 
 
-class AcceptLanguage(Accept):
+class AcceptLanguage(object):
     """
-    Represents an ``Accept-Language`` header.
+    Represent an ``Accept-Language`` header.
+
+    Base class for :class:`AcceptLanguageValidHeader`,
+    :class:`AcceptLanguageNoHeader`, and :class:`AcceptLanguageInvalidHeader`.
     """
-    def _match(self, mask, item):
-        item = item.replace('_', '-').lower()
-        mask = mask.lower()
-        return (mask == '*'
-            or item == mask
-            or item.split('-')[0] == mask
-            or item == mask.split('-')[0]
-        )
 
 
 class AcceptLanguageValidHeader(AcceptLanguage):

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1653,7 +1653,7 @@ class AcceptLanguageNoHeader(_AcceptLanguageInvalidOrNoHeader):
         return self.__add__(other=other)
 
     def __repr__(self):
-        return '{}()'.format(self.__class__.__name__)
+        return '<{}>'.format(self.__class__.__name__)
 
     def __str__(self):
         """Return the ``str`` ``'<no header in request>'``."""
@@ -1791,7 +1791,7 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
     def __repr__(self):
         # The header value is untrusted input, so if it is not valid, we will
         # not risk returning it in an eval()-able form
-        return '<AcceptLanguageInvalidHeader instance>'
+        return '<{}>'.format(self.__class__.__name__)
 
     def __str__(self):
         """Return the ``str`` ``'<invalid header value>'``."""

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -533,12 +533,7 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         )
 
     def __repr__(self):
-        return '<{}>'.format(self.__class__.__name__)
-        # We use angle brackets to indicate that it is not in eval()-able form.
-        # We do not display the header_value, as it is untrusted input; there
-        # could be a mistake in the validating regex or elsewhere. The
-        # header_value could always be easily obtained from the .header_value
-        # property.
+        return '<{} ({!r})>'.format(self.__class__.__name__, str(self))
 
     def __str__(self):
         r"""
@@ -1779,7 +1774,6 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
 
     def __repr__(self):
         return '<{}>'.format(self.__class__.__name__)
-        # We use angle brackets to indicate that it is not in eval()-able form.
         # We do not display the header_value, as it is untrusted input. The
         # header_value could always be easily obtained from the .header_value
         # property.

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1784,9 +1784,11 @@ class AcceptLanguageInvalidHeader(_AcceptLanguageInvalidOrNoHeader):
         )
 
     def __repr__(self):
-        # The header value is untrusted input, so if it is not valid, we will
-        # not risk returning it in an eval()-able form
         return '<{}>'.format(self.__class__.__name__)
+        # We use angle brackets to indicate that it is not in eval()-able form.
+        # We do not display the header_value, as it is untrusted input. The
+        # header_value could always be easily obtained from the .header_value
+        # property.
 
     def __str__(self):
         """Return the ``str`` ``'<invalid header value>'``."""

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -353,7 +353,10 @@ class AcceptLanguageValidHeader(AcceptLanguage):
         """
         self._header_value = header_value
         self._parsed = list(self.parse(header_value))
-        self._parsed_nonzero = [(m, q) for (m, q) in self.parsed if q]
+        self._parsed_nonzero = [
+            (language_range, qvalue) for language_range, qvalue in self.parsed
+            if qvalue
+        ]
 
     @property
     def header_value(self):

--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -13,12 +13,12 @@ import warnings
 
 from webob.acceptparse import (
     AcceptEncoding,
-    AcceptLanguage,
     AcceptCharset,
     MIMEAccept,
     MIMENilAccept,
     NoAccept,
     accept_property,
+    accept_language_property,
     )
 
 from webob.cachecontrol import (
@@ -1044,7 +1044,7 @@ class BaseRequest(object):
     accept_encoding = accept_property('Accept-Encoding', '14.3',
                                       AcceptClass=AcceptEncoding,
                                       NilClass=NoAccept)
-    accept_language = accept_property('Accept-Language', '14.4', AcceptLanguage)
+    accept_language = accept_language_property()
 
     authorization = converter(
         environ_getter('HTTP_AUTHORIZATION', None, '14.8'),

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -145,6 +145,14 @@ def test_accept_match():
         assert 'text/html' in Accept(mask)
     assert 'text/html' not in Accept('foo/bar')
 
+
+def test_accept_iter():
+    accept = Accept(
+        'text/plain; q=0.5, text/html; q=0, text/x-dvi; q=0.8, text/x-c'
+    )
+    assert list(accept) == ['text/x-c', 'text/x-dvi', 'text/plain']
+
+
 # NilAccept tests
 
 def test_nil():
@@ -194,6 +202,10 @@ def test_nil_best_match():
     assert nilaccept.best_match([('foo', 0.5), 'bar'],
                                 default_match=False) == 'bar'
     assert nilaccept.best_match([], default_match='fallback') == 'fallback'
+
+def test_nil_iter():
+    nilaccept = NilAccept()
+    assert list(nilaccept) == []
 
 
 # NoAccept tests

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1524,6 +1524,189 @@ class TestAcceptLanguageNoHeader(object):
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
 
+    def test___add___None(self):
+        Cls = self._get_class()
+        instance = Cls()
+        result = instance + None
+        assert isinstance(result, Cls)
+        assert result is not instance
+
+    @pytest.mark.parametrize('right_operand', ['', (), [], {}])
+    def test___add___non_accept_language_instance_non_None_falsy_value(
+        self, right_operand,
+    ):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        instance = Cls()
+        result = instance + right_operand
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == ''
+
+    def test___add___other_type_with_empty___str__(self):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        instance = Cls()
+        class Other(object):
+            def __str__(self):
+                return ''
+        result = instance + Other()
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == ''
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___valid_value(self, value, value_as_header):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        result = Cls() + value
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == value_as_header
+
+    def test___add___other_type_with_valid___str__(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        right_operand = Other()
+        result = Cls() + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == str(right_operand)
+
+    @pytest.mark.parametrize('right_operand', [
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___add___non_empty_invalid_value(self, right_operand):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        result = Cls() + right_operand
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == 'en_gb'
+
+    def test___add___other_type_with_non_empty_invalid___str__(self):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return '/'
+        right_operand = Other()
+        result = Cls() + right_operand
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == str(right_operand)
+
+    def test___add___AcceptLanguageValidHeader(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        header = ', ,fr;q=0, \tes;q=1,'
+        result = Cls() + AcceptLanguageValidHeader(header_value=header)
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == header
+
+    def test___add___AcceptLanguageNoHeader(self):
+        Cls = self._get_class()
+        left_operand_instance = Cls()
+        right_operand_instance = Cls()
+        result = left_operand_instance + right_operand_instance
+        assert isinstance(result, Cls)
+        assert result is not left_operand_instance
+        assert result is not right_operand_instance
+
+    @pytest.mark.parametrize('invalid_header_value', ['', '/'])
+    def test___add___AcceptLanguageInvalidHeader(self, invalid_header_value):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        invalid_header_instance = AcceptLanguageInvalidHeader(
+            header_value=invalid_header_value,
+        )
+        result = Cls() + invalid_header_instance
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == invalid_header_instance.header_value
+        assert result is not invalid_header_instance
+
+    def test___radd___None(self):
+        Cls = self._get_class()
+        instance = Cls()
+        result = instance + None
+        assert isinstance(result, Cls)
+        assert result is not instance
+
+    @pytest.mark.parametrize('left_operand', ['', (), [], {}])
+    def test___radd___non_accept_language_instance_non_None_falsy_value(
+        self, left_operand,
+    ):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        instance = Cls()
+        result = left_operand + instance
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == ''
+
+    def test___radd___other_type_with_empty___str__(self):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        instance = Cls()
+        class Other(object):
+            def __str__(self):
+                return ''
+        result = Other() + instance
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == ''
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___valid_value(self, value, value_as_header):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        result = value + Cls()
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == value_as_header
+
+    def test___radd___other_type_with_valid___str__(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        left_operand = Other()
+        result = left_operand + Cls()
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == str(left_operand)
+
+    @pytest.mark.parametrize('left_operand', [
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___radd___non_empty_invalid_value(self, left_operand):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        result = left_operand + Cls()
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == 'en_gb'
+
+    def test___radd___other_type_with_non_empty_invalid___str__(self):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return '/'
+        left_operand = Other()
+        result = left_operand + Cls()
+        assert isinstance(result, AcceptLanguageInvalidHeader)
+        assert result.header_value == str(left_operand)
+
     def test_repr(self):
         instance = self._get_class()()
         assert repr(instance) == 'AcceptLanguageNoHeader()'

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -821,9 +821,8 @@ class TestAcceptLanguageValidHeader(object):
         header_value = ',da;q=0.2,en-gb;q=0.3'
         instance = self._get_class()(header_value=header_value)
         assert repr(instance) == (
-            "AcceptLanguageValidHeader(header_value={!r})".format(
-                header_value
-            )
+            '<AcceptLanguageValidHeader '
+            "header_value=',da;q=0.2,en-gb;q=0.3'>"
         )
 
     def test___str__(self):

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -942,7 +942,7 @@ class TestAcceptLanguageValidHeader(object):
 
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = AcceptLanguageValidHeader(header_value='valid-header')
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             instance.lookup(
                 language_tags=['tag'],
                 default_range='language-range',
@@ -952,7 +952,7 @@ class TestAcceptLanguageValidHeader(object):
 
     def test_lookup_default_range_cannot_be_asterisk(self):
         instance = AcceptLanguageValidHeader(header_value='valid-header')
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             instance.lookup(
                 language_tags=['tag'],
                 default_range='*',
@@ -1632,7 +1632,7 @@ class TestAcceptLanguageNoHeader(object):
 
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = AcceptLanguageNoHeader()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             instance.lookup(default_tag=None, default=None)
 
     @pytest.mark.parametrize('default_tag, default, expected', [
@@ -1823,7 +1823,7 @@ class TestAcceptLanguageInvalidHeader(object):
 
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = AcceptLanguageInvalidHeader(header_value='')
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             instance.lookup(default_tag=None, default=None)
 
     @pytest.mark.parametrize('default_tag, default, expected', [

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -550,27 +550,45 @@ class TestAcceptLanguageValidHeader(object):
         ]
         assert isinstance(instance, AcceptLanguage)
 
-    @pytest.mark.parametrize('right_operand', [None, '', (), [], {}])
-    def test___add___non_accept_language_instance_falsy_value(
-        self, right_operand,
-    ):
-        header = ',\t ,de, zh-Hans;q=0.333,'
-        instance = AcceptLanguageValidHeader(header_value=header)
-        result = instance + right_operand
+    def test___add___None(self):
+        left_operand = AcceptLanguageValidHeader(header_value='en')
+        result = left_operand + None
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header
-        assert result is not instance
+        assert result.header_value == left_operand.header_value
+        assert result is not left_operand
 
-    def test___add___other_type_with_empty___str__(self):
-        header = ',\t ,de, zh-Hans;q=0.333,'
-        instance = AcceptLanguageValidHeader(header_value=header)
+    @pytest.mark.parametrize('right_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+        ',',
+        [','],
+        (','),
+        {',': 1.0},
+    ])
+    def test___add___invalid_value(self, right_operand):
+        left_operand = AcceptLanguageValidHeader(header_value='en')
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == left_operand.header_value
+        assert result is not left_operand
+
+    @pytest.mark.parametrize('str_', ['', 'en_gb', ','])
+    def test___add___other_type_with_invalid___str__(self, str_,):
+        left_operand = AcceptLanguageValidHeader(header_value='en')
         class Other(object):
             def __str__(self):
-                return ''
-        result = instance + Other()
+                return str_
+        right_operand = Other()
+        result = left_operand + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header
-        assert result is not instance
+        assert result.header_value == left_operand.header_value
+        assert result is not left_operand
 
     @pytest.mark.parametrize('value, value_as_header', [
         ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
@@ -594,50 +612,6 @@ class TestAcceptLanguageValidHeader(object):
         assert isinstance(result, AcceptLanguageValidHeader)
         assert result.header_value == header + ', ' + str(right_operand)
 
-    @pytest.mark.parametrize('right_operand', [
-        'en_gb',
-        ['en_gb'],
-        ('en_gb'),
-        {'en_gb': 1.0},
-    ])
-    def test___add___non_empty_invalid_value__invalid_result(
-        self, right_operand,
-    ):
-        header = 'en'
-        result = AcceptLanguageValidHeader(header_value=header) + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == header + ', ' + 'en_gb'
-
-    def test___add___other_type_with_non_empty_invalid___str____invalid_result(
-        self,
-    ):
-        header = 'en'
-        class Other(object):
-            def __str__(self):
-                return '/'
-        right_operand = Other()
-        result = AcceptLanguageValidHeader(header_value=header) + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == header + ', ' + str(right_operand)
-
-    def test___add___non_empty_invalid_value__valid_result(self):
-        header = 'en'
-        result = AcceptLanguageValidHeader(header_value=header) + ','
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header + ', ' + ','
-
-    def test___add___other_type_with_non_empty_invalid___str____valid_result(
-        self,
-    ):
-        header = 'en'
-        class Other(object):
-            def __str__(self):
-                return ','
-        right_operand = Other()
-        result = AcceptLanguageValidHeader(header_value=header) + right_operand
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header + ', ' + ','
-
     def test___add___AcceptLanguageValidHeader(self):
         header1 = ',\t ,de, zh-Hans;q=0.333,'
         header2 = ', ,fr;q=0, \tes;q=1,'
@@ -653,55 +627,56 @@ class TestAcceptLanguageValidHeader(object):
         assert result.header_value == valid_header_instance.header_value
         assert result is not valid_header_instance
 
-    def test___add___AcceptLanguageInvalidHeader_empty(self):
+    @pytest.mark.parametrize('header_value', ['', 'en_gb', ','])
+    def test___add___AcceptLanguageInvalidHeader(self, header_value):
         valid_header_instance = AcceptLanguageValidHeader(
             header_value='header',
         )
         result = valid_header_instance + AcceptLanguageInvalidHeader(
-            header_value='',
+            header_value=header_value,
         )
         assert isinstance(result, AcceptLanguageValidHeader)
         assert result.header_value == valid_header_instance.header_value
         assert result is not valid_header_instance
 
-    def test___add___AcceptLanguageInvalidHeader_non_empty_invalid_result(
-        self,
-    ):
-        left_operand = AcceptLanguageValidHeader(header_value='header')
-        right_operand = AcceptLanguageInvalidHeader(header_value='/')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            right_operand.header_value
+    def test___radd___None(self):
+        right_operand = AcceptLanguageValidHeader(header_value='en')
+        result = None + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == right_operand.header_value
+        assert result is not right_operand
 
-    def test___add___AcceptLanguageInvalidHeader_non_empty_valid_result(self):
-        left_operand = AcceptLanguageValidHeader(header_value='header')
-        right_operand = AcceptLanguageInvalidHeader(header_value=',')
+    @pytest.mark.parametrize('left_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+        ',',
+        [','],
+        (','),
+        {',': 1.0},
+    ])
+    def test___radd___invalid_value(self, left_operand):
+        right_operand = AcceptLanguageValidHeader(header_value='en')
         result = left_operand + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + ','
+        assert result.header_value == right_operand.header_value
+        assert result is not right_operand
 
-    @pytest.mark.parametrize('left_operand', [None, '', (), [], {}])
-    def test___radd___non_accept_language_instance_falsy_value(
-        self, left_operand,
-    ):
-        header = ',\t ,de, zh-Hans;q=0.333,'
-        instance = AcceptLanguageValidHeader(header_value=header)
-        result = left_operand + instance
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header
-        assert result is not instance
-
-    def test___radd___other_type_with_empty___str__(self):
-        header = ',\t ,de, zh-Hans;q=0.333,'
-        instance = AcceptLanguageValidHeader(header_value=header)
+    @pytest.mark.parametrize('str_', ['', 'en_gb', ','])
+    def test___radd___other_type_with_invalid___str__(self, str_,):
+        right_operand = AcceptLanguageValidHeader(header_value='en')
         class Other(object):
             def __str__(self):
-                return ''
-        result = Other() + instance
+                return str_
+        result = Other() + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header
-        assert result is not instance
+        assert result.header_value == right_operand.header_value
+        assert result is not right_operand
 
     @pytest.mark.parametrize('value, value_as_header', [
         ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
@@ -710,64 +685,26 @@ class TestAcceptLanguageValidHeader(object):
         ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
     ])
     def test___radd___valid_value(self, value, value_as_header):
-        header = ',\t ,de, zh-Hans;q=0.333,'
-        result = value + AcceptLanguageValidHeader(header_value=header)
+        right_operand = AcceptLanguageValidHeader(
+            header_value=',\t ,de, zh-Hans;q=0.333,',
+        )
+        result = value + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == value_as_header + ', ' + header
+        assert result.header_value == value_as_header + ', ' + \
+            right_operand.header_value
 
     def test___radd___other_type_with_valid___str__(self):
-        header = ',\t ,de, zh-Hans;q=0.333,'
+        right_operand = AcceptLanguageValidHeader(
+            header_value=',\t ,de, zh-Hans;q=0.333,',
+        )
         class Other(object):
             def __str__(self):
                 return 'en-gb;q=0.5, fr;q=0, es'
         left_operand = Other()
-        result = left_operand + AcceptLanguageValidHeader(header_value=header)
+        result = left_operand + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == str(left_operand) + ', ' + header
-
-    @pytest.mark.parametrize('left_operand', [
-        'en_gb',
-        ['en_gb'],
-        ('en_gb'),
-        {'en_gb': 1.0},
-    ])
-    def test___radd___non_empty_invalid_value__invalid_result(
-        self, left_operand,
-    ):
-        header = 'en'
-        result = left_operand + AcceptLanguageValidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == 'en_gb' + ', ' + header
-
-    def test___radd___other_type_with_non_empty_invalid_str__invalid_result(
-        self,
-    ):
-        header = 'en'
-        class Other(object):
-            def __str__(self):
-                return '/'
-        left_operand = Other()
-        result = left_operand + AcceptLanguageValidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(left_operand) + ', ' + header
-
-    def test___radd___non_empty_invalid_value__valid_result(self):
-        header = 'en'
-        result = ',' + AcceptLanguageValidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == ',' + ', ' + header
-
-    def test___radd___other_type_with_non_empty_invalid___str____valid_result(
-        self,
-    ):
-        header = 'en'
-        class Other(object):
-            def __str__(self):
-                return ','
-        left_operand = Other()
-        result = left_operand + AcceptLanguageValidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == ',' + ', ' + header
+        assert result.header_value == str(left_operand) + ', ' + \
+            right_operand.header_value
 
     def test___bool__(self):
         instance = AcceptLanguageValidHeader(header_value='valid-header')
@@ -1527,23 +1464,31 @@ class TestAcceptLanguageNoHeader(object):
         assert isinstance(result, AcceptLanguageNoHeader)
         assert result is not instance
 
-    @pytest.mark.parametrize('right_operand', ['', (), [], {}])
-    def test___add___non_accept_language_instance_non_None_falsy_value(
-        self, right_operand,
-    ):
-        instance = AcceptLanguageNoHeader()
-        result = instance + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == ''
+    @pytest.mark.parametrize('right_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___add___invalid_value(self, right_operand):
+        left_operand = AcceptLanguageNoHeader()
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageNoHeader)
+        assert result is not left_operand
 
-    def test___add___other_type_with_empty___str__(self):
-        instance = AcceptLanguageNoHeader()
+    @pytest.mark.parametrize('str_', ['', 'en_gb'])
+    def test___add___other_type_with_invalid___str__(self, str_,):
+        left_operand = AcceptLanguageNoHeader()
         class Other(object):
             def __str__(self):
-                return ''
-        result = instance + Other()
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == ''
+                return str_
+        result = left_operand + Other()
+        assert isinstance(result, AcceptLanguageNoHeader)
+        assert result is not left_operand
 
     @pytest.mark.parametrize('value, value_as_header', [
         ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
@@ -1565,51 +1510,30 @@ class TestAcceptLanguageNoHeader(object):
         assert isinstance(result, AcceptLanguageValidHeader)
         assert result.header_value == str(right_operand)
 
-    @pytest.mark.parametrize('right_operand', [
-        'en_gb',
-        ['en_gb'],
-        ('en_gb'),
-        {'en_gb': 1.0},
-    ])
-    def test___add___non_empty_invalid_value(self, right_operand):
-        result = AcceptLanguageNoHeader() + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == 'en_gb'
-
-    def test___add___other_type_with_non_empty_invalid___str__(self):
-        class Other(object):
-            def __str__(self):
-                return '/'
-        right_operand = Other()
-        result = AcceptLanguageNoHeader() + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(right_operand)
-
     def test___add___AcceptLanguageValidHeader(self):
-        header = ', ,fr;q=0, \tes;q=1,'
-        result = AcceptLanguageNoHeader() + AcceptLanguageValidHeader(
-            header_value=header,
+        right_operand = AcceptLanguageValidHeader(
+            header_value=', ,fr;q=0, \tes;q=1,',
         )
+        result = AcceptLanguageNoHeader() + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header
+        assert result.header_value == right_operand.header_value
 
     def test___add___AcceptLanguageNoHeader(self):
-        left_operand_instance = AcceptLanguageNoHeader()
-        right_operand_instance = AcceptLanguageNoHeader()
-        result = left_operand_instance + right_operand_instance
+        left_operand = AcceptLanguageNoHeader()
+        right_operand = AcceptLanguageNoHeader()
+        result = left_operand + right_operand
         assert isinstance(result, AcceptLanguageNoHeader)
-        assert result is not left_operand_instance
-        assert result is not right_operand_instance
+        assert result is not left_operand
+        assert result is not right_operand
 
-    @pytest.mark.parametrize('invalid_header_value', ['', '/'])
+    @pytest.mark.parametrize('invalid_header_value', ['', 'en_gb'])
     def test___add___AcceptLanguageInvalidHeader(self, invalid_header_value):
-        invalid_header_instance = AcceptLanguageInvalidHeader(
+        left_operand = AcceptLanguageNoHeader()
+        result = left_operand + AcceptLanguageInvalidHeader(
             header_value=invalid_header_value,
         )
-        result = AcceptLanguageNoHeader() + invalid_header_instance
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == invalid_header_instance.header_value
-        assert result is not invalid_header_instance
+        assert isinstance(result, AcceptLanguageNoHeader)
+        assert result is not left_operand
 
     def test___bool__(self):
         instance = AcceptLanguageNoHeader()
@@ -1632,23 +1556,31 @@ class TestAcceptLanguageNoHeader(object):
         assert isinstance(result, AcceptLanguageNoHeader)
         assert result is not instance
 
-    @pytest.mark.parametrize('left_operand', ['', (), [], {}])
-    def test___radd___non_accept_language_instance_non_None_falsy_value(
-        self, left_operand,
-    ):
-        instance = AcceptLanguageNoHeader()
-        result = left_operand + instance
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == ''
+    @pytest.mark.parametrize('left_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___radd___invalid_value(self, left_operand):
+        right_operand = AcceptLanguageNoHeader()
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageNoHeader)
+        assert result is not right_operand
 
-    def test___radd___other_type_with_empty___str__(self):
-        instance = AcceptLanguageNoHeader()
+    @pytest.mark.parametrize('str_', ['', 'en_gb', ','])
+    def test___radd___other_type_with_invalid___str__(self, str_,):
+        right_operand = AcceptLanguageNoHeader()
         class Other(object):
             def __str__(self):
-                return ''
-        result = Other() + instance
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == ''
+                return str_
+        result = Other() + right_operand
+        assert isinstance(result, AcceptLanguageNoHeader)
+        assert result is not right_operand
 
     @pytest.mark.parametrize('value, value_as_header', [
         ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
@@ -1668,26 +1600,6 @@ class TestAcceptLanguageNoHeader(object):
         left_operand = Other()
         result = left_operand + AcceptLanguageNoHeader()
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == str(left_operand)
-
-    @pytest.mark.parametrize('left_operand', [
-        'en_gb',
-        ['en_gb'],
-        ('en_gb'),
-        {'en_gb': 1.0},
-    ])
-    def test___radd___non_empty_invalid_value(self, left_operand):
-        result = left_operand + AcceptLanguageNoHeader()
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == 'en_gb'
-
-    def test___radd___other_type_with_non_empty_invalid___str__(self):
-        class Other(object):
-            def __str__(self):
-                return '/'
-        left_operand = Other()
-        result = left_operand + AcceptLanguageNoHeader()
-        assert isinstance(result, AcceptLanguageInvalidHeader)
         assert result.header_value == str(left_operand)
 
     def test___repr__(self):
@@ -1756,235 +1668,69 @@ class TestAcceptLanguageInvalidHeader(object):
         assert instance._parsed_nonzero is None
         assert isinstance(instance, AcceptLanguage)
 
-    @pytest.mark.parametrize('left_operand_header, right_operand', [
-        ('', None),
-        ('', ''),
-        ('', ()),
-        ('', []),
-        ('', {}),
-        ('/', None),
-        ('/', ''),
-        ('/', ()),
-        ('/', []),
-        ('/', {}),
-    ])
-    def test___add___non_accept_language_instance_falsy_value(
-        self, left_operand_header, right_operand,
-    ):
-        instance = AcceptLanguageInvalidHeader(
-            header_value=left_operand_header,
-        )
-        result = instance + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand_header
-        assert result is not instance
+    def test___add___None(self):
+        instance = AcceptLanguageInvalidHeader(header_value='')
+        result = instance + None
+        assert isinstance(result, AcceptLanguageNoHeader)
 
-    @pytest.mark.parametrize('left_operand_header', ['', '/'])
-    def test___add___other_type_empty_value(self, left_operand_header):
-        instance = AcceptLanguageInvalidHeader(header_value=left_operand_header)
+    @pytest.mark.parametrize('right_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___add___invalid_value(self, right_operand):
+        result = AcceptLanguageInvalidHeader(header_value='') + right_operand
+        assert isinstance(result, AcceptLanguageNoHeader)
+
+    @pytest.mark.parametrize('str_', ['', 'en_gb'])
+    def test___add___other_type_with_invalid___str__(self, str_):
         class Other(object):
             def __str__(self):
-                return ''
-        result = instance + Other()
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand_header
-        assert result is not instance
+                return str_
+        result = AcceptLanguageInvalidHeader(header_value='') + Other()
+        assert isinstance(result, AcceptLanguageNoHeader)
 
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    @pytest.mark.parametrize('value', [
+        'en',
+        ['en'],
+        ('en', ),
+        {'en': 1.0},
     ])
-    def test___add___empty_header__non_empty_valid_value(
-        self, value, value_as_header,
-    ):
+    def test___add___valid_header_value(self, value):
         result = AcceptLanguageInvalidHeader(header_value='') + value
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == value_as_header
+        assert result.header_value == 'en'
 
-    def test___add___empty_header__other_type_non_empty_valid_value(self):
+    def test___add___other_type_valid_header_value(self):
         class Other(object):
             def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        right_operand = Other()
-        result = AcceptLanguageInvalidHeader(header_value='') + right_operand
+                return 'en'
+        result = AcceptLanguageInvalidHeader(header_value='') + Other()
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == str(right_operand)
+        assert result.header_value == 'en'
 
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
-        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
-        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
-        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
-    ])
-    def test___add___empty_header__non_empty_invalid_value(
-        self, value, value_as_header,
-    ):
-        result = AcceptLanguageInvalidHeader(header_value='') + value
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == value_as_header
-
-    def test___add___empty_header__other_type_non_empty_invalid_value(self):
-        class Other(object):
-            def __str__(self):
-                return 'en_gb;q=0.5, fr;q=0, es'
-        right_operand = Other()
-        result = AcceptLanguageInvalidHeader(header_value='') + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(right_operand)
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
-    ])
-    def test___add___non_empty_header__valid_value__invalid_result(
-        self, value, value_as_header,
-    ):
-        header = '/'
-        result = AcceptLanguageInvalidHeader(header_value=header) + value
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == header + ', ' + value_as_header
-
-    def test___add___non_empty_header__other_type_valid_value__invalid_result(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        left_operand = AcceptLanguageInvalidHeader(header_value='/')
-        right_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            str(right_operand)
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
-    ])
-    def test___add___non_empty_header__valid_value__valid_result(
-        self, value, value_as_header,
-    ):
-        header = ','
-        result = AcceptLanguageInvalidHeader(header_value=header) + value
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == header + ', ' + value_as_header
-
-    def test___add___non_empty_header__other_type_valid_value__valid_result(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        left_operand = AcceptLanguageInvalidHeader(header_value=',')
-        right_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            str(right_operand)
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
-        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
-        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
-        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
-    ])
-    def test___add___non_empty_header__non_empty_invalid_value(
-        self, value, value_as_header,
-    ):
-        left_operand = AcceptLanguageInvalidHeader(header_value='zh_Hans')
-        result = left_operand + value
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            value_as_header
-
-    def test___add___non_empty_header__other_type_non_empty_invalid_value(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        left_operand = AcceptLanguageInvalidHeader(header_value='zh_Hans')
-        right_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            str(right_operand)
-
-    def test___add___empty_header__AcceptLanguageValidHeader(self):
+    def test___add___AcceptLanguageValidHeader(self):
         right_operand = AcceptLanguageValidHeader(header_value='en')
         result = AcceptLanguageInvalidHeader(header_value='') + right_operand
         assert isinstance(result, AcceptLanguageValidHeader)
         assert result.header_value == right_operand.header_value
         assert result is not right_operand
 
-    def test___add___non_empty_header__AcceptLanguageValidHeader__invalid_res(
-        self,
-    ):
-        left_operand = AcceptLanguageInvalidHeader(header_value='/')
-        right_operand = AcceptLanguageValidHeader(header_value='en')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            right_operand.header_value
-
-    def test___add___non_empty_header__AcceptLanguageValidHeader__valid_result(
-        self,
-    ):
-        left_operand = AcceptLanguageInvalidHeader(header_value=',')
-        right_operand = AcceptLanguageValidHeader(header_value='en')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            right_operand.header_value
-
-    @pytest.mark.parametrize('header_value', ['', '/'])
-    def test___add___AcceptLanguageNoHeader(self, header_value):
-        invalid_header_instance = AcceptLanguageInvalidHeader(
-            header_value=header_value,
-        )
-        result = invalid_header_instance + AcceptLanguageNoHeader()
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == invalid_header_instance.header_value
-        assert result is not invalid_header_instance
-
-    def test___add___AcceptLanguageInvalidHeader__both_empty(self):
-        left_operand = AcceptLanguageInvalidHeader(header_value='')
-        right_operand = AcceptLanguageInvalidHeader(header_value='')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == ''
-        assert result is not left_operand
+    def test___add___AcceptLanguageNoHeader(self):
+        right_operand = AcceptLanguageNoHeader()
+        result = AcceptLanguageInvalidHeader(header_value='') + right_operand
+        assert isinstance(result, AcceptLanguageNoHeader)
         assert result is not right_operand
 
-    def test___add___AcceptLanguageInvalidHeader__left_empty(self):
-        left_operand = AcceptLanguageInvalidHeader(header_value='')
-        right_operand = AcceptLanguageInvalidHeader(header_value='en_gb')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == 'en_gb'
-        assert result is not right_operand
-
-    def test___add___AcceptLanguageInvalidHeader__right_empty(self):
-        left_operand = AcceptLanguageInvalidHeader(header_value='en_gb')
-        right_operand = AcceptLanguageInvalidHeader(header_value='')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == 'en_gb'
-        assert result is not left_operand
-
-    def test___add___AcceptLanguageInvalidHeader__both_not_empty(self):
-        left_operand = AcceptLanguageInvalidHeader(header_value='en_gb')
-        right_operand = AcceptLanguageInvalidHeader(header_value='en_gb')
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == left_operand.header_value + ', ' + \
-            right_operand.header_value
+    def test___add___AcceptLanguageInvalidHeader(self):
+        result = AcceptLanguageInvalidHeader(header_value='') + \
+            AcceptLanguageInvalidHeader(header_value='')
+        assert isinstance(result, AcceptLanguageNoHeader)
 
     def test___bool__(self):
         instance = AcceptLanguageInvalidHeader(header_value='')
@@ -2001,167 +1747,51 @@ class TestAcceptLanguageInvalidHeader(object):
         returned = list(instance)
         assert returned == []
 
-    @pytest.mark.parametrize('right_operand_header, left_operand', [
-        ('', None),
-        ('', ''),
-        ('', ()),
-        ('', []),
-        ('', {}),
-        ('/', None),
-        ('/', ''),
-        ('/', ()),
-        ('/', []),
-        ('/', {}),
-    ])
-    def test___radd___non_accept_language_instance_falsy_value(
-        self, right_operand_header, left_operand,
-    ):
-        instance = AcceptLanguageInvalidHeader(
-            header_value=right_operand_header,
-        )
-        result = left_operand + instance
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == right_operand_header
-        assert result is not instance
+    def test___radd___None(self):
+        instance = AcceptLanguageInvalidHeader(header_value='')
+        result = None + instance
+        assert isinstance(result, AcceptLanguageNoHeader)
 
-    @pytest.mark.parametrize('right_operand_header', ['', '/'])
-    def test___radd___other_type_empty_value(self, right_operand_header):
-        instance = AcceptLanguageInvalidHeader(
-            header_value=right_operand_header,
-        )
+    @pytest.mark.parametrize('left_operand', [
+        '',
+        [],
+        (),
+        {},
+        'en_gb',
+        ['en_gb'],
+        ('en_gb'),
+        {'en_gb': 1.0},
+    ])
+    def test___radd___invalid_value(self, left_operand):
+        result = left_operand + AcceptLanguageInvalidHeader(header_value='')
+        assert isinstance(result, AcceptLanguageNoHeader)
+
+    @pytest.mark.parametrize('str_', ['', 'en_gb'])
+    def test___radd___other_type_with_invalid___str__(self, str_):
         class Other(object):
             def __str__(self):
-                return ''
-        result = Other() + instance
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == right_operand_header
-        assert result is not instance
+                return str_
+        result = Other() + AcceptLanguageInvalidHeader(header_value='')
+        assert isinstance(result, AcceptLanguageNoHeader)
 
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    @pytest.mark.parametrize('value', [
+        'en',
+        ['en'],
+        ('en', ),
+        {'en': 1.0},
     ])
-    def test___radd___empty_header__non_empty_valid_value(
-        self, value, value_as_header,
-    ):
+    def test___radd___valid_header_value(self, value):
         result = value + AcceptLanguageInvalidHeader(header_value='')
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == value_as_header
+        assert result.header_value == 'en'
 
-    def test___radd___empty_header__other_type_non_empty_valid_value(self):
+    def test___radd___other_type_valid_header_value(self):
         class Other(object):
             def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        left_operand = Other()
-        result = left_operand + AcceptLanguageInvalidHeader(header_value='')
+                return 'en'
+        result = Other() + AcceptLanguageInvalidHeader(header_value='')
         assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == str(left_operand)
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
-        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
-        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
-        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
-    ])
-    def test___radd___empty_header__non_empty_invalid_value(
-        self, value, value_as_header,
-    ):
-        result = value + AcceptLanguageInvalidHeader(header_value='')
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == value_as_header
-
-    def test___radd___empty_header__other_type_non_empty_invalid_value(self):
-        class Other(object):
-            def __str__(self):
-                return 'en_gb;q=0.5, fr;q=0, es'
-        left_operand = Other()
-        result = left_operand + AcceptLanguageInvalidHeader(header_value='')
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(left_operand)
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
-    ])
-    def test___radd___non_empty_header__valid_value__invalid_result(
-        self, value, value_as_header,
-    ):
-        header = '/'
-        result = value + AcceptLanguageInvalidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == value_as_header + ', ' + header
-
-    def test___radd___non_empty_header__other_type_valid_value__invalid_result(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        right_operand = AcceptLanguageInvalidHeader(header_value='/')
-        left_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(left_operand) + ', ' + \
-            right_operand.header_value
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
-        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
-        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
-        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
-    ])
-    def test___radd___non_empty_header__valid_value__valid_result(
-        self, value, value_as_header,
-    ):
-        header = ','
-        result = value + AcceptLanguageInvalidHeader(header_value=header)
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == value_as_header + ', ' + header
-
-    def test___radd___non_empty_header__other_type_valid_value__valid_result(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        right_operand = AcceptLanguageInvalidHeader(header_value=',')
-        left_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageValidHeader)
-        assert result.header_value == str(left_operand) + ', ' + \
-            right_operand.header_value
-
-    @pytest.mark.parametrize('value, value_as_header', [
-        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
-        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
-        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
-        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
-    ])
-    def test___radd___non_empty_header__non_empty_invalid_value(
-        self, value, value_as_header,
-    ):
-        right_operand = AcceptLanguageInvalidHeader(header_value='zh_Hans')
-        result = value + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == value_as_header + ', ' + \
-            right_operand.header_value
-
-    def test___radd___non_empty_header__other_type_non_empty_invalid_value(
-        self,
-    ):
-        class Other(object):
-            def __str__(self):
-                return 'en-gb;q=0.5, fr;q=0, es'
-        right_operand = AcceptLanguageInvalidHeader(header_value='zh_Hans')
-        left_operand = Other()
-        result = left_operand + right_operand
-        assert isinstance(result, AcceptLanguageInvalidHeader)
-        assert result.header_value == str(left_operand) + ', ' + \
-            right_operand.header_value
+        assert result.header_value == 'en'
 
     def test___repr__(self):
         instance = AcceptLanguageInvalidHeader(header_value='\x00')

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -515,17 +515,17 @@ class TestAcceptLanguageValidHeader(object):
         from webob.acceptparse import AcceptLanguage
         header_value = \
             'zh-Hant;q=0.372,zh-CN-a-myExt-x-private;q=0.977,de,*;q=0.000'
-        accept_language = self._get_class()(header_value=header_value)
-        assert accept_language.header_value == header_value
-        assert accept_language.parsed == [
+        instance = self._get_class()(header_value=header_value)
+        assert instance.header_value == header_value
+        assert instance.parsed == [
             ('zh-Hant', 0.372), ('zh-CN-a-myExt-x-private', 0.977),
             ('de', 1.0), ('*', 0.0)
         ]
-        assert accept_language._parsed_nonzero == [
+        assert instance._parsed_nonzero == [
             ('zh-Hant', 0.372), ('zh-CN-a-myExt-x-private', 0.977),
             ('de', 1.0)
         ]
-        assert isinstance(accept_language, AcceptLanguage)
+        assert isinstance(instance, AcceptLanguage)
 
     @pytest.mark.parametrize('right_operand', [None, '', (), [], {}])
     def test___add___non_accept_language_instance_falsy_value(
@@ -1525,11 +1525,11 @@ class TestAcceptLanguageNoHeader(object):
 
     def test___init__(self):
         from webob.acceptparse import AcceptLanguage
-        accept_language = self._get_class()()
-        assert accept_language.header_value is None
-        assert accept_language.parsed is None
-        assert accept_language._parsed_nonzero is None
-        assert isinstance(accept_language, AcceptLanguage)
+        instance = self._get_class()()
+        assert instance.header_value is None
+        assert instance.parsed is None
+        assert instance._parsed_nonzero is None
+        assert isinstance(instance, AcceptLanguage)
 
     def test___add___None(self):
         Cls = self._get_class()
@@ -1794,11 +1794,11 @@ class TestAcceptLanguageInvalidHeader(object):
     def test___init__(self):
         from webob.acceptparse import AcceptLanguage
         header_value = 'invalid header'
-        accept_language = self._get_class()(header_value=header_value)
-        assert accept_language.header_value == header_value
-        assert accept_language.parsed is None
-        assert accept_language._parsed_nonzero is None
-        assert isinstance(accept_language, AcceptLanguage)
+        instance = self._get_class()(header_value=header_value)
+        assert instance.header_value == header_value
+        assert instance.parsed is None
+        assert instance._parsed_nonzero is None
+        assert isinstance(instance, AcceptLanguage)
 
     @pytest.mark.parametrize('left_operand_header, right_operand', [
         ('', None),

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -965,6 +965,37 @@ class TestAcceptLanguageValidHeader(object):
         returned = instance.basic_filtering(language_tags=language_tags)
         assert returned == expected_returned
 
+    @pytest.mark.parametrize(
+        'header_value, offers, default_match, expected_returned', [
+            ('bar, *;q=0', ['foo'], None, None),
+            ('en-gb, sr-Cyrl', ['sr-Cyrl', 'en-gb'], None, 'sr-Cyrl'),
+            ('en-gb, sr-Cyrl', ['en-gb', 'sr-Cyrl'], None, 'en-gb'),
+            ('en-gb, sr-Cyrl', [('sr-Cyrl', 0.5), 'en-gb'], None, 'en-gb'),
+            (
+                'en-gb, sr-Cyrl', [('sr-Cyrl', 0.5), ('en-gb', 0.4)], None,
+                'sr-Cyrl',
+            ),
+            ('en-gb, sr-Cyrl;q=0.5', ['en-gb', 'sr-Cyrl'], None, 'en-gb'),
+            ('en-gb;q=0.5, sr-Cyrl', ['en-gb', 'sr-Cyrl'], None, 'sr-Cyrl'),
+            (
+                'en-gb, sr-Cyrl;q=0.55, es;q=0.59', ['en-gb', 'sr-Cyrl'], None,
+                'en-gb',
+            ),
+            (
+                'en-gb;q=0.5, sr-Cyrl;q=0.586, es-419;q=0.597',
+                ['en-gb', 'es-419'], None, 'es-419',
+            ),
+        ]
+    )
+    def test_best_match(
+        self, header_value, offers, default_match, expected_returned,
+    ):
+        instance = self._get_class()(header_value=header_value)
+        returned = instance.best_match(
+            offers=offers, default_match=default_match,
+        )
+        assert returned == expected_returned
+
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = self._get_class()(header_value='valid-header')
         with pytest.raises(AssertionError):

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1730,7 +1730,7 @@ class TestAcceptLanguageNoHeader(object):
 
     def test___repr__(self):
         instance = self._get_class()()
-        assert repr(instance) == 'AcceptLanguageNoHeader()'
+        assert repr(instance) == '<AcceptLanguageNoHeader>'
 
     def test___str__(self):
         instance = self._get_class()()
@@ -2244,7 +2244,7 @@ class TestAcceptLanguageInvalidHeader(object):
 
     def test___repr__(self):
         instance = self._get_class()(header_value='\x00')
-        assert repr(instance) == '<AcceptLanguageInvalidHeader instance>'
+        assert repr(instance) == '<AcceptLanguageInvalidHeader>'
 
     def test___str__(self):
         instance = self._get_class()(header_value="invalid header")

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -2244,13 +2244,8 @@ class TestAcceptLanguageInvalidHeader(object):
             right_operand.header_value
 
     def test___repr__(self):
-        header_value = """\"\"\"invalid\n\x00'header\""""
-        instance = self._get_class()(header_value=header_value)
-        assert repr(instance) == (
-            "AcceptLanguageInvalidHeader(header_value={!r})".format(
-                header_value
-            )
-        )
+        instance = self._get_class()(header_value='\x00')
+        assert repr(instance) == '<AcceptLanguageInvalidHeader instance>'
 
     def test___str__(self):
         instance = self._get_class()(header_value="invalid header")

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -818,8 +818,9 @@ class TestAcceptLanguageValidHeader(object):
         assert list(instance) == expected_list
 
     def test___repr__(self):
-        instance = self._get_class()(header_value=',da;q=0.2,en-gb;q=0.3')
-        assert repr(instance) == '<AcceptLanguageValidHeader>'
+        instance = self._get_class()(header_value=',da;q=0.200,en-gb;q=0.300')
+        assert repr(instance) == \
+            "<AcceptLanguageValidHeader ('da;q=0.2, en-gb;q=0.3')>"
 
     def test___str__(self):
         header_value = \

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -495,11 +495,11 @@ class TestAcceptLanguageValidHeader(object):
         '',
         ', da;q=0.2, en-gb;q=0.3 ',
     ])
-    def test_init_invalid_header(self, header_value):
+    def test___init___invalid_header(self, header_value):
         with pytest.raises(ValueError):
             self._get_class()(header_value=header_value)
 
-    def test_init_valid_header(self):
+    def test___init___valid_header(self):
         header_value = \
             'zh-Hant;q=0.372,zh-CN-a-myExt-x-private;q=0.977,de,*;q=0.000'
         accept_language = self._get_class()(header_value=header_value)
@@ -802,6 +802,21 @@ class TestAcceptLanguageValidHeader(object):
     def test___iter__(self, header_value, expected_list):
         instance = self._get_class()(header_value=header_value)
         assert list(instance) == expected_list
+
+    def test___repr__(self):
+        header_value = ',da;q=0.2,en-gb;q=0.3'
+        instance = self._get_class()(header_value=header_value)
+        assert repr(instance) == (
+            "AcceptLanguageValidHeader(header_value={!r})".format(
+                header_value
+            )
+        )
+
+    def test___str__(self):
+        header_value = \
+            ', \t,de;q=0.000 \t, es;q=1.000, zh, jp;q=0.210  ,'
+        instance = self._get_class()(header_value=header_value)
+        assert str(instance) == 'de;q=0, es, zh, jp;q=0.21'
 
     @pytest.mark.parametrize(
         'header_value, language_tags, expected_returned',
@@ -1447,28 +1462,13 @@ class TestAcceptLanguageValidHeader(object):
         )
         assert returned == expected
 
-    def test_repr(self):
-        header_value = ',da;q=0.2,en-gb;q=0.3'
-        instance = self._get_class()(header_value=header_value)
-        assert repr(instance) == (
-            "AcceptLanguageValidHeader(header_value={!r})".format(
-                header_value
-            )
-        )
-
-    def test_str(self):
-        header_value = \
-            ', \t,de;q=0.000 \t, es;q=1.000, zh, jp;q=0.210  ,'
-        instance = self._get_class()(header_value=header_value)
-        assert str(instance) == 'de;q=0, es, zh, jp;q=0.21'
-
 
 class TestAcceptLanguageNoHeader(object):
     def _get_class(self):
         from webob.acceptparse import AcceptLanguageNoHeader
         return AcceptLanguageNoHeader
 
-    def test_init(self):
+    def test___init__(self):
         accept_language = self._get_class()()
         assert accept_language.header_value is None
         assert accept_language.parsed is None
@@ -1672,11 +1672,11 @@ class TestAcceptLanguageNoHeader(object):
         assert isinstance(result, AcceptLanguageInvalidHeader)
         assert result.header_value == str(left_operand)
 
-    def test_repr(self):
+    def test___repr__(self):
         instance = self._get_class()()
         assert repr(instance) == 'AcceptLanguageNoHeader()'
 
-    def test_str(self):
+    def test___str__(self):
         instance = self._get_class()()
         assert str(instance) == '<no header in request>'
 
@@ -1714,7 +1714,7 @@ class TestAcceptLanguageInvalidHeader(object):
         from webob.acceptparse import AcceptLanguageInvalidHeader
         return AcceptLanguageInvalidHeader
 
-    def test_init(self):
+    def test___init__(self):
         header_value = 'invalid header'
         accept_language = self._get_class()(header_value=header_value)
         assert accept_language.header_value == header_value
@@ -2164,7 +2164,7 @@ class TestAcceptLanguageInvalidHeader(object):
         assert result.header_value == str(left_operand) + ', ' + \
             right_operand.header_value
 
-    def test_repr(self):
+    def test___repr__(self):
         header_value = """\"\"\"invalid\n\x00'header\""""
         instance = self._get_class()(header_value=header_value)
         assert repr(instance) == (
@@ -2173,7 +2173,7 @@ class TestAcceptLanguageInvalidHeader(object):
             )
         )
 
-    def test_str(self):
+    def test___str__(self):
         instance = self._get_class()(header_value="invalid header")
         assert str(instance) == '<invalid header value>'
 

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1720,6 +1720,21 @@ class TestAcceptLanguageNoHeader(object):
         returned = instance.basic_filtering(language_tags=['tag1', 'tag2'])
         assert returned == []
 
+    @pytest.mark.parametrize('offers, default_match, expected_returned', [
+        (['foo', 'bar'], None, 'foo'),
+        ([('foo', 1), ('bar', 0.5)], None, 'foo'),
+        ([('foo', 0.5), ('bar', 1)], None, 'bar'),
+        ([('foo', 0.5), 'bar'], None, 'bar'),
+        ([('foo', 0.5), 'bar'], object(), 'bar'),
+        ([], 'fallback', 'fallback'),
+    ])
+    def test_best_match(self, offers, default_match, expected_returned):
+        instance = self._get_class()()
+        returned = instance.best_match(
+            offers=offers, default_match=default_match,
+        )
+        assert returned == expected_returned
+
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = self._get_class()()
         with pytest.raises(AssertionError):
@@ -2218,6 +2233,21 @@ class TestAcceptLanguageInvalidHeader(object):
         instance = self._get_class()(header_value='')
         returned = instance.basic_filtering(language_tags=['tag1', 'tag2'])
         assert returned == []
+
+    @pytest.mark.parametrize('offers, default_match, expected_returned', [
+        (['foo', 'bar'], None, 'foo'),
+        ([('foo', 1), ('bar', 0.5)], None, 'foo'),
+        ([('foo', 0.5), ('bar', 1)], None, 'bar'),
+        ([('foo', 0.5), 'bar'], None, 'bar'),
+        ([('foo', 0.5), 'bar'], object(), 'bar'),
+        ([], 'fallback', 'fallback'),
+    ])
+    def test_best_match(self, offers, default_match, expected_returned):
+        instance = self._get_class()(header_value='')
+        returned = instance.best_match(
+            offers=offers, default_match=default_match,
+        )
+        assert returned == expected_returned
 
     def test_lookup_default_tag_and_default_cannot_both_be_None(self):
         instance = self._get_class()(header_value='')

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1463,56 +1463,6 @@ class TestAcceptLanguageValidHeader(object):
         assert str(instance) == 'de;q=0, es, zh, jp;q=0.21'
 
 
-class Test__AcceptLanguageInvalidOrNoHeader(object):
-    def _get_class(self):
-        from webob.acceptparse import _AcceptLanguageInvalidOrNoHeader
-        return _AcceptLanguageInvalidOrNoHeader
-
-    def test___bool__(self):
-        instance = self._get_class()(header_value='')
-        returned = bool(instance)
-        assert returned is False
-
-    def test___contains__(self):
-        instance = self._get_class()(header_value='')
-        returned = ('any-tag' in instance)
-        assert returned is True
-
-    def test___iter__(self):
-        instance = self._get_class()(header_value='')
-        returned = list(instance)
-        assert returned == []
-
-    def test_basic_filtering(self):
-        instance = self._get_class()(header_value='')
-        returned = instance.basic_filtering(language_tags=['tag1', 'tag2'])
-        assert returned == []
-
-    def test_lookup_default_tag_and_default_cannot_both_be_None(self):
-        instance = self._get_class()(header_value='')
-        with pytest.raises(AssertionError):
-            instance.lookup(default_tag=None, default=None)
-
-    @pytest.mark.parametrize('default_tag, default, expected', [
-        # If `default_tag` is not None, it is returned.
-        ('default-tag', 'default', 'default-tag'),
-        # If `default_tag` is None, we proceed to the `default` argument. If
-        # `default` is not a callable, the argument itself is returned.
-        (None, 0, 0),
-        # If `default` is a callable, it is called, and the callable's return
-        # value is returned by the method.
-        (None, lambda: 'callable called', 'callable called'),
-    ])
-    def test_lookup(self, default_tag, default, expected):
-        instance = self._get_class()(header_value='')
-        returned = instance.lookup(
-            default_tag=default_tag,
-            default=default,
-        )
-        assert returned == expected
-
-
-
 class TestAcceptLanguageNoHeader(object):
     def _get_class(self):
         from webob.acceptparse import AcceptLanguageNoHeader
@@ -1630,6 +1580,21 @@ class TestAcceptLanguageNoHeader(object):
         assert result.header_value == invalid_header_instance.header_value
         assert result is not invalid_header_instance
 
+    def test___bool__(self):
+        instance = self._get_class()()
+        returned = bool(instance)
+        assert returned is False
+
+    def test___contains__(self):
+        instance = self._get_class()()
+        returned = ('any-tag' in instance)
+        assert returned is True
+
+    def test___iter__(self):
+        instance = self._get_class()()
+        returned = list(instance)
+        assert returned == []
+
     def test___radd___None(self):
         Cls = self._get_class()
         instance = Cls()
@@ -1714,6 +1679,35 @@ class TestAcceptLanguageNoHeader(object):
     def test_str(self):
         instance = self._get_class()()
         assert str(instance) == '<no header in request>'
+
+    def test_basic_filtering(self):
+        instance = self._get_class()()
+        returned = instance.basic_filtering(language_tags=['tag1', 'tag2'])
+        assert returned == []
+
+    def test_lookup_default_tag_and_default_cannot_both_be_None(self):
+        instance = self._get_class()()
+        with pytest.raises(AssertionError):
+            instance.lookup(default_tag=None, default=None)
+
+    @pytest.mark.parametrize('default_tag, default, expected', [
+        # If `default_tag` is not None, it is returned.
+        ('default-tag', 'default', 'default-tag'),
+        # If `default_tag` is None, we proceed to the `default` argument. If
+        # `default` is not a callable, the argument itself is returned.
+        (None, 0, 0),
+        # If `default` is a callable, it is called, and the callable's return
+        # value is returned by the method.
+        (None, lambda: 'callable called', 'callable called'),
+    ])
+    def test_lookup(self, default_tag, default, expected):
+        instance = self._get_class()()
+        returned = instance.lookup(
+            default_tag=default_tag,
+            default=default,
+        )
+        assert returned == expected
+
 
 class TestAcceptLanguageInvalidHeader(object):
     def _get_class(self):
@@ -1981,6 +1975,21 @@ class TestAcceptLanguageInvalidHeader(object):
         assert result.header_value == left_operand.header_value + ', ' + \
             right_operand.header_value
 
+    def test___bool__(self):
+        instance = self._get_class()(header_value='')
+        returned = bool(instance)
+        assert returned is False
+
+    def test___contains__(self):
+        instance = self._get_class()(header_value='')
+        returned = ('any-tag' in instance)
+        assert returned is True
+
+    def test___iter__(self):
+        instance = self._get_class()(header_value='')
+        returned = list(instance)
+        assert returned == []
+
     @pytest.mark.parametrize('right_operand_header, left_operand', [
         ('', None),
         ('', ''),
@@ -2167,6 +2176,34 @@ class TestAcceptLanguageInvalidHeader(object):
     def test_str(self):
         instance = self._get_class()(header_value="invalid header")
         assert str(instance) == '<invalid header value>'
+
+    def test_basic_filtering(self):
+        instance = self._get_class()(header_value='')
+        returned = instance.basic_filtering(language_tags=['tag1', 'tag2'])
+        assert returned == []
+
+    def test_lookup_default_tag_and_default_cannot_both_be_None(self):
+        instance = self._get_class()(header_value='')
+        with pytest.raises(AssertionError):
+            instance.lookup(default_tag=None, default=None)
+
+    @pytest.mark.parametrize('default_tag, default, expected', [
+        # If `default_tag` is not None, it is returned.
+        ('default-tag', 'default', 'default-tag'),
+        # If `default_tag` is None, we proceed to the `default` argument. If
+        # `default` is not a callable, the argument itself is returned.
+        (None, 0, 0),
+        # If `default` is a callable, it is called, and the callable's return
+        # value is returned by the method.
+        (None, lambda: 'callable called', 'callable called'),
+    ])
+    def test_lookup(self, default_tag, default, expected):
+        instance = self._get_class()(header_value='')
+        returned = instance.lookup(
+            default_tag=default_tag,
+            default=default,
+        )
+        assert returned == expected
 
 
 class TestCreateAcceptLanguageHeader(object):

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1211,6 +1211,12 @@ class TestAcceptLanguageValidHeader(object):
             )
         )
 
+    def test_str(self):
+        header_value = \
+            ', \t,de;q=0.000 \t, es;q=1.000, zh, jp;q=0.210  ,'
+        instance = self._get_class()(header_value=header_value)
+        assert str(instance) == 'de;q=0, es, zh, jp;q=0.21'
+
 
 class Test__AcceptLanguageInvalidOrNoHeader(object):
     def _get_class(self):
@@ -1277,6 +1283,9 @@ class TestAcceptLanguageNoHeader(object):
         instance = self._get_class()()
         assert repr(instance) == 'AcceptLanguageNoHeader()'
 
+    def test_str(self):
+        instance = self._get_class()()
+        assert str(instance) == '<no header in request>'
 
 class TestAcceptLanguageInvalidHeader(object):
     def _get_class(self):
@@ -1298,3 +1307,7 @@ class TestAcceptLanguageInvalidHeader(object):
                 header_value
             )
         )
+
+    def test_str(self):
+        instance = self._get_class()(header_value="invalid header")
+        assert str(instance) == '<invalid header value>'

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -818,12 +818,8 @@ class TestAcceptLanguageValidHeader(object):
         assert list(instance) == expected_list
 
     def test___repr__(self):
-        header_value = ',da;q=0.2,en-gb;q=0.3'
-        instance = self._get_class()(header_value=header_value)
-        assert repr(instance) == (
-            '<AcceptLanguageValidHeader '
-            "header_value=',da;q=0.2,en-gb;q=0.3'>"
-        )
+        instance = self._get_class()(header_value=',da;q=0.2,en-gb;q=0.3')
+        assert repr(instance) == '<AcceptLanguageValidHeader>'
 
     def test___str__(self):
         header_value = \

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1311,3 +1311,33 @@ class TestAcceptLanguageInvalidHeader(object):
     def test_str(self):
         instance = self._get_class()(header_value="invalid header")
         assert str(instance) == '<invalid header value>'
+
+
+class TestCreateAcceptLanguageHeader(object):
+    def _get_function(self):
+        from webob.acceptparse import create_accept_language_header
+        return create_accept_language_header
+
+    def test_header_value_is_None(self):
+        from webob.acceptparse import AcceptLanguageNoHeader
+        function = self._get_function()
+        header_value = None
+        returned = function(header_value=header_value)
+        assert isinstance(returned, AcceptLanguageNoHeader)
+        assert returned.header_value == header_value
+
+    def test_header_value_is_valid(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        function = self._get_function()
+        header_value = 'es, ja'
+        returned = function(header_value=header_value)
+        assert isinstance(returned, AcceptLanguageValidHeader)
+        assert returned.header_value == header_value
+
+    @pytest.mark.parametrize('header_value', ['', 'en_gb'])
+    def test_header_value_is_invalid(self, header_value):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        function = self._get_function()
+        returned = function(header_value=header_value)
+        assert isinstance(returned, AcceptLanguageInvalidHeader)
+        assert returned.header_value == header_value

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1553,10 +1553,10 @@ class TestAcceptLanguageNoHeader(object):
         assert returned == []
 
     def test___radd___None(self):
-        instance = AcceptLanguageNoHeader()
-        result = instance + None
+        right_operand = AcceptLanguageNoHeader()
+        result = None + right_operand
         assert isinstance(result, AcceptLanguageNoHeader)
-        assert result is not instance
+        assert result is not right_operand
 
     @pytest.mark.parametrize('left_operand', [
         '',

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1727,6 +1727,434 @@ class TestAcceptLanguageInvalidHeader(object):
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
 
+    @pytest.mark.parametrize('left_operand_header, right_operand', [
+        ('', None),
+        ('', ''),
+        ('', ()),
+        ('', []),
+        ('', {}),
+        ('/', None),
+        ('/', ''),
+        ('/', ()),
+        ('/', []),
+        ('/', {}),
+    ])
+    def test___add___non_accept_language_instance_falsy_value(
+        self, left_operand_header, right_operand,
+    ):
+        Cls = self._get_class()
+        instance = Cls(header_value=left_operand_header)
+        result = instance + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand_header
+        assert result is not instance
+
+    @pytest.mark.parametrize('left_operand_header', ['', '/'])
+    def test___add___other_type_empty_value(self, left_operand_header):
+        Cls = self._get_class()
+        instance = Cls(header_value=left_operand_header)
+        class Other(object):
+            def __str__(self):
+                return ''
+        result = instance + Other()
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand_header
+        assert result is not instance
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___empty_header__non_empty_valid_value(
+        self, value, value_as_header,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        result = Cls(header_value='') + value
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == value_as_header
+
+    def test___add___empty_header__other_type_non_empty_valid_value(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        right_operand = Other()
+        result = Cls(header_value='') + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == str(right_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
+        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
+        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
+        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___empty_header__non_empty_invalid_value(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        result = Cls(header_value='') + value
+        assert isinstance(result, Cls)
+        assert result.header_value == value_as_header
+
+    def test___add___empty_header__other_type_non_empty_invalid_value(self):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en_gb;q=0.5, fr;q=0, es'
+        right_operand = Other()
+        result = Cls(header_value='') + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == str(right_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___non_empty_header__valid_value__invalid_result(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        header = '/'
+        result = Cls(header_value=header) + value
+        assert isinstance(result, Cls)
+        assert result.header_value == header + ', ' + value_as_header
+
+    def test___add___non_empty_header__other_type_valid_value__invalid_result(
+        self,
+    ):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        left_operand = Cls(header_value='/')
+        right_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            str(right_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___non_empty_header__valid_value__valid_result(
+        self, value, value_as_header,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        header = ','
+        result = Cls(header_value=header) + value
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == header + ', ' + value_as_header
+
+    def test___add___non_empty_header__other_type_valid_value__valid_result(
+        self,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        left_operand = Cls(header_value=',')
+        right_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            str(right_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
+        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
+        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
+        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
+    ])
+    def test___add___non_empty_header__non_empty_invalid_value(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        left_operand = Cls(header_value='zh_Hans')
+        result = left_operand + value
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            value_as_header
+
+    def test___add___non_empty_header__other_type_non_empty_invalid_value(
+        self,
+    ):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        left_operand = Cls(header_value='zh_Hans')
+        right_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            str(right_operand)
+
+    def test___add___empty_header__AcceptLanguageValidHeader(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        right_operand = AcceptLanguageValidHeader(header_value='en')
+        result = Cls(header_value='') + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == right_operand.header_value
+        assert result is not right_operand
+
+    def test___add___non_empty_header__AcceptLanguageValidHeader__invalid_res(
+        self,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        left_operand = Cls(header_value='/')
+        right_operand = AcceptLanguageValidHeader(header_value='en')
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            right_operand.header_value
+
+    def test___add___non_empty_header__AcceptLanguageValidHeader__valid_result(
+        self,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        left_operand = Cls(header_value=',')
+        right_operand = AcceptLanguageValidHeader(header_value='en')
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            right_operand.header_value
+
+    @pytest.mark.parametrize('header_value', ['', '/'])
+    def test___add___AcceptLanguageNoHeader(self, header_value):
+        from webob.acceptparse import AcceptLanguageNoHeader
+        Cls = self._get_class()
+        invalid_header_instance = Cls(header_value=header_value)
+        result = invalid_header_instance + AcceptLanguageNoHeader()
+        assert isinstance(result, Cls)
+        assert result.header_value == invalid_header_instance.header_value
+        assert result is not invalid_header_instance
+
+    def test___add___AcceptLanguageInvalidHeader__both_empty(self):
+        Cls = self._get_class()
+        left_operand = Cls(header_value='')
+        right_operand = Cls(header_value='')
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == ''
+        assert result is not left_operand
+        assert result is not right_operand
+
+    def test___add___AcceptLanguageInvalidHeader__left_empty(self):
+        Cls = self._get_class()
+        left_operand = Cls(header_value='')
+        right_operand = Cls(header_value='en_gb')
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == 'en_gb'
+        assert result is not right_operand
+
+    def test___add___AcceptLanguageInvalidHeader__right_empty(self):
+        Cls = self._get_class()
+        left_operand = Cls(header_value='en_gb')
+        right_operand = Cls(header_value='')
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == 'en_gb'
+        assert result is not left_operand
+
+    def test___add___AcceptLanguageInvalidHeader__both_not_empty(self):
+        Cls = self._get_class()
+        left_operand = Cls(header_value='en_gb')
+        right_operand = Cls(header_value='en_gb')
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == left_operand.header_value + ', ' + \
+            right_operand.header_value
+
+    @pytest.mark.parametrize('right_operand_header, left_operand', [
+        ('', None),
+        ('', ''),
+        ('', ()),
+        ('', []),
+        ('', {}),
+        ('/', None),
+        ('/', ''),
+        ('/', ()),
+        ('/', []),
+        ('/', {}),
+    ])
+    def test___radd___non_accept_language_instance_falsy_value(
+        self, right_operand_header, left_operand,
+    ):
+        Cls = self._get_class()
+        instance = Cls(header_value=right_operand_header)
+        result = left_operand + instance
+        assert isinstance(result, Cls)
+        assert result.header_value == right_operand_header
+        assert result is not instance
+
+    @pytest.mark.parametrize('right_operand_header', ['', '/'])
+    def test___radd___other_type_empty_value(self, right_operand_header):
+        Cls = self._get_class()
+        instance = Cls(header_value=right_operand_header)
+        class Other(object):
+            def __str__(self):
+                return ''
+        result = Other() + instance
+        assert isinstance(result, Cls)
+        assert result.header_value == right_operand_header
+        assert result is not instance
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___empty_header__non_empty_valid_value(
+        self, value, value_as_header,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        result = value + Cls(header_value='')
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == value_as_header
+
+    def test___radd___empty_header__other_type_non_empty_valid_value(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        left_operand = Other()
+        result = left_operand + Cls(header_value='')
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == str(left_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
+        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
+        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
+        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___empty_header__non_empty_invalid_value(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        result = value + Cls(header_value='')
+        assert isinstance(result, Cls)
+        assert result.header_value == value_as_header
+
+    def test___radd___empty_header__other_type_non_empty_invalid_value(self):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en_gb;q=0.5, fr;q=0, es'
+        left_operand = Other()
+        result = left_operand + Cls(header_value='')
+        assert isinstance(result, Cls)
+        assert result.header_value == str(left_operand)
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___non_empty_header__valid_value__invalid_result(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        header = '/'
+        result = value + Cls(header_value=header)
+        assert isinstance(result, Cls)
+        assert result.header_value == value_as_header + ', ' + header
+
+    def test___radd___non_empty_header__other_type_valid_value__invalid_result(
+        self,
+    ):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        right_operand = Cls(header_value='/')
+        left_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == str(left_operand) + ', ' + \
+            right_operand.header_value
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en-gb;q=0.5, fr;q=0, es', 'en-gb;q=0.5, fr;q=0, es'),
+        ([('en-gb', 0.5), ('fr', 0.0), 'es'], 'en-gb;q=0.5, fr;q=0, es'),
+        ((('en-gb', 0.5), ('fr', 0.0), 'es'), 'en-gb;q=0.5, fr;q=0, es'),
+        ({'en-gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en-gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___non_empty_header__valid_value__valid_result(
+        self, value, value_as_header,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        header = ','
+        result = value + Cls(header_value=header)
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == value_as_header + ', ' + header
+
+    def test___radd___non_empty_header__other_type_valid_value__valid_result(
+        self,
+    ):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        right_operand = Cls(header_value=',')
+        left_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, AcceptLanguageValidHeader)
+        assert result.header_value == str(left_operand) + ', ' + \
+            right_operand.header_value
+
+    @pytest.mark.parametrize('value, value_as_header', [
+        ('en_gb;q=0.5, fr;q=0, es', 'en_gb;q=0.5, fr;q=0, es'),
+        ([('en_gb', 0.5), ('fr', 0.0), 'es'], 'en_gb;q=0.5, fr;q=0, es'),
+        ((('en_gb', 0.5), ('fr', 0.0), 'es'), 'en_gb;q=0.5, fr;q=0, es'),
+        ({'en_gb': 0.5, 'fr': 0.0, 'es': 1.0}, 'es, en_gb;q=0.5, fr;q=0'),
+    ])
+    def test___radd___non_empty_header__non_empty_invalid_value(
+        self, value, value_as_header,
+    ):
+        Cls = self._get_class()
+        right_operand = Cls(header_value='zh_Hans')
+        result = value + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == value_as_header + ', ' + \
+            right_operand.header_value
+
+    def test___radd___non_empty_header__other_type_non_empty_invalid_value(
+        self,
+    ):
+        Cls = self._get_class()
+        class Other(object):
+            def __str__(self):
+                return 'en-gb;q=0.5, fr;q=0, es'
+        right_operand = Cls(header_value='zh_Hans')
+        left_operand = Other()
+        result = left_operand + right_operand
+        assert isinstance(result, Cls)
+        assert result.header_value == str(left_operand) + ', ' + \
+            right_operand.header_value
+
     def test_repr(self):
         header_value = """\"\"\"invalid\n\x00'header\""""
         instance = self._get_class()(header_value=header_value)

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -467,7 +467,7 @@ def test_accept_property_fdel():
     assert type(desc.fget(req)) == NilAccept
 
 
-class TestAcceptLanguageValidHeader(object):
+class TestAcceptLanguage(object):
     @pytest.mark.parametrize('value', [
         '',
         '*s',
@@ -490,7 +490,7 @@ class TestAcceptLanguageValidHeader(object):
     ])
     def test_parse__invalid_header(self, value):
         with pytest.raises(ValueError):
-            AcceptLanguageValidHeader.parse(value=value)
+            AcceptLanguage.parse(value=value)
 
     @pytest.mark.parametrize('value, expected_list', [
         ('*', [('*', 1.0)]),
@@ -523,10 +523,12 @@ class TestAcceptLanguageValidHeader(object):
         ('foo , ,bar,charlie', [('foo', 1.0), ('bar', 1.0), ('charlie', 1.0)]),
     ])
     def test_parse__valid_header(self, value, expected_list):
-        returned = AcceptLanguageValidHeader.parse(value=value)
+        returned = AcceptLanguage.parse(value=value)
         list_of_returned = list(returned)
         assert list_of_returned == expected_list
 
+
+class TestAcceptLanguageValidHeader(object):
     @pytest.mark.parametrize('header_value', [
         '',
         ', da;q=0.2, en-gb;q=0.3 ',

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -564,11 +564,11 @@ class TestAcceptLanguageValidHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
         ',',
         [','],
-        (','),
+        (',',),
         {',': 1.0},
     ])
     def test___add___invalid_value(self, right_operand):
@@ -653,11 +653,11 @@ class TestAcceptLanguageValidHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
         ',',
         [','],
-        (','),
+        (',',),
         {',': 1.0},
     ])
     def test___radd___invalid_value(self, left_operand):
@@ -1471,7 +1471,7 @@ class TestAcceptLanguageNoHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
     ])
     def test___add___invalid_value(self, right_operand):
@@ -1563,7 +1563,7 @@ class TestAcceptLanguageNoHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
     ])
     def test___radd___invalid_value(self, left_operand):
@@ -1680,7 +1680,7 @@ class TestAcceptLanguageInvalidHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
     ])
     def test___add___invalid_value(self, right_operand):
@@ -1698,7 +1698,7 @@ class TestAcceptLanguageInvalidHeader(object):
     @pytest.mark.parametrize('value', [
         'en',
         ['en'],
-        ('en', ),
+        ('en',),
         {'en': 1.0},
     ])
     def test___add___valid_header_value(self, value):
@@ -1759,7 +1759,7 @@ class TestAcceptLanguageInvalidHeader(object):
         {},
         'en_gb',
         ['en_gb'],
-        ('en_gb'),
+        ('en_gb',),
         {'en_gb': 1.0},
     ])
     def test___radd___invalid_value(self, left_operand):
@@ -1777,7 +1777,7 @@ class TestAcceptLanguageInvalidHeader(object):
     @pytest.mark.parametrize('value', [
         'en',
         ['en'],
-        ('en', ),
+        ('en',),
         {'en': 1.0},
     ])
     def test___radd___valid_header_value(self, value):

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1495,6 +1495,16 @@ class TestAcceptLanguageValidHeader(object):
         )
         assert returned == expected
 
+    @pytest.mark.parametrize('header_value, offer, expected_returned', [
+        ('en-gb', 'en-gb', 1),
+        ('en-gb;q=0.5', 'en-gb', 0.5),
+        ('en-gb', 'sr-Cyrl', None),
+    ])
+    def test_quality(self, header_value, offer, expected_returned):
+        instance = self._get_class()(header_value=header_value)
+        returned = instance.quality(offer=offer)
+        assert returned == expected_returned
+
 
 class TestAcceptLanguageNoHeader(object):
     def _get_class(self):
@@ -1757,6 +1767,11 @@ class TestAcceptLanguageNoHeader(object):
             default=default,
         )
         assert returned == expected
+
+    def test_quality(self):
+        instance = self._get_class()()
+        returned = instance.quality(offer='any-tag')
+        assert returned == 1.0
 
 
 class TestAcceptLanguageInvalidHeader(object):
@@ -2271,6 +2286,11 @@ class TestAcceptLanguageInvalidHeader(object):
             default=default,
         )
         assert returned == expected
+
+    def test_quality(self):
+        instance = self._get_class()(header_value='')
+        returned = instance.quality(offer='any-tag')
+        assert returned == 1.0
 
 
 class TestCreateAcceptLanguageHeader(object):

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -500,6 +500,7 @@ class TestAcceptLanguageValidHeader(object):
             self._get_class()(header_value=header_value)
 
     def test___init___valid_header(self):
+        from webob.acceptparse import AcceptLanguage
         header_value = \
             'zh-Hant;q=0.372,zh-CN-a-myExt-x-private;q=0.977,de,*;q=0.000'
         accept_language = self._get_class()(header_value=header_value)
@@ -512,6 +513,7 @@ class TestAcceptLanguageValidHeader(object):
             ('zh-Hant', 0.372), ('zh-CN-a-myExt-x-private', 0.977),
             ('de', 1.0)
         ]
+        assert isinstance(accept_language, AcceptLanguage)
 
     @pytest.mark.parametrize('right_operand', [None, '', (), [], {}])
     def test___add___non_accept_language_instance_falsy_value(
@@ -1469,10 +1471,12 @@ class TestAcceptLanguageNoHeader(object):
         return AcceptLanguageNoHeader
 
     def test___init__(self):
+        from webob.acceptparse import AcceptLanguage
         accept_language = self._get_class()()
         assert accept_language.header_value is None
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
+        assert isinstance(accept_language, AcceptLanguage)
 
     def test___add___None(self):
         Cls = self._get_class()
@@ -1715,11 +1719,13 @@ class TestAcceptLanguageInvalidHeader(object):
         return AcceptLanguageInvalidHeader
 
     def test___init__(self):
+        from webob.acceptparse import AcceptLanguage
         header_value = 'invalid header'
         accept_language = self._get_class()(header_value=header_value)
         assert accept_language.header_value == header_value
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
+        assert isinstance(accept_language, AcceptLanguage)
 
     @pytest.mark.parametrize('left_operand_header, right_operand', [
         ('', None),

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1202,6 +1202,15 @@ class TestAcceptLanguageValidHeader(object):
         )
         assert returned == expected
 
+    def test_repr(self):
+        header_value = ',da;q=0.2,en-gb;q=0.3'
+        instance = self._get_class()(header_value=header_value)
+        assert repr(instance) == (
+            "AcceptLanguageValidHeader(header_value={!r})".format(
+                header_value
+            )
+        )
+
 
 class Test__AcceptLanguageInvalidOrNoHeader(object):
     def _get_class(self):
@@ -1264,6 +1273,10 @@ class TestAcceptLanguageNoHeader(object):
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
 
+    def test_repr(self):
+        instance = self._get_class()()
+        assert repr(instance) == 'AcceptLanguageNoHeader()'
+
 
 class TestAcceptLanguageInvalidHeader(object):
     def _get_class(self):
@@ -1276,3 +1289,12 @@ class TestAcceptLanguageInvalidHeader(object):
         assert accept_language.header_value == header_value
         assert accept_language.parsed is None
         assert accept_language._parsed_nonzero is None
+
+    def test_repr(self):
+        header_value = """\"\"\"invalid\n\x00'header\""""
+        instance = self._get_class()(header_value=header_value)
+        assert repr(instance) == (
+            "AcceptLanguageInvalidHeader(header_value={!r})".format(
+                header_value
+            )
+        )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -11,6 +11,11 @@ from io import (
 
 import pytest
 
+from webob.acceptparse import (
+    AcceptLanguageInvalidHeader,
+    AcceptLanguageNoHeader,
+    AcceptLanguageValidHeader,
+    )
 from webob.compat import (
     bytes_,
     native_,
@@ -704,7 +709,6 @@ class TestRequestCommon(object):
 
     # accept_language
     def test_accept_language_no_header(self):
-        from webob.acceptparse import AcceptLanguageNoHeader
         req = self._makeOne(environ={})
         header = req.accept_language
         assert isinstance(header, AcceptLanguageNoHeader)
@@ -712,14 +716,12 @@ class TestRequestCommon(object):
 
     @pytest.mark.parametrize('header_value', ['', ', da;q=0.2, en-gb;q =0.3'])
     def test_accept_language_invalid_header(self, header_value):
-        from webob.acceptparse import AcceptLanguageInvalidHeader
         req = self._makeOne(environ={'HTTP_ACCEPT_LANGUAGE': header_value})
         header = req.accept_language
         assert isinstance(header, AcceptLanguageInvalidHeader)
         assert header.header_value == header_value
 
     def test_accept_language_valid_header(self):
-        from webob.acceptparse import AcceptLanguageValidHeader
         header_value = \
             'zh-Hant;q=0.372,zh-CN-a-myExt-x-private;q=0.977,de,*;q=0.000'
         req = self._makeOne(environ={'HTTP_ACCEPT_LANGUAGE': header_value})

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -701,7 +701,32 @@ class TestRequestCommon(object):
     # accept
     # accept_charset
     # accept_encoding
+
     # accept_language
+    def test_accept_language_no_header(self):
+        from webob.acceptparse import AcceptLanguageNoHeader
+        req = self._makeOne(environ={})
+        header = req.accept_language
+        assert isinstance(header, AcceptLanguageNoHeader)
+        assert header.header_value is None
+
+    @pytest.mark.parametrize('header_value', ['', ', da;q=0.2, en-gb;q =0.3'])
+    def test_accept_language_invalid_header(self, header_value):
+        from webob.acceptparse import AcceptLanguageInvalidHeader
+        req = self._makeOne(environ={'HTTP_ACCEPT_LANGUAGE': header_value})
+        header = req.accept_language
+        assert isinstance(header, AcceptLanguageInvalidHeader)
+        assert header.header_value == header_value
+
+    def test_accept_language_valid_header(self):
+        from webob.acceptparse import AcceptLanguageValidHeader
+        header_value = \
+            'zh-Hant;q=0.372,zh-CN-a-myExt-x-private;q=0.977,de,*;q=0.000'
+        req = self._makeOne(environ={'HTTP_ACCEPT_LANGUAGE': header_value})
+        header = req.accept_language
+        assert isinstance(header, AcceptLanguageValidHeader)
+        assert header.header_value == header_value
+
     # authorization
 
     # cache_control


### PR DESCRIPTION
Some remaining questions:

1. How would you like me to do the imports in the tests? I can switch to module scope or fixtures, if either is your preference. (Module scope does seem to produce quite a lot of noise when one import is broken though, especially with tox and coverage, and I don't think fixtures are being used for imports in any WebOb tests at the moment.)
2. Would you prefer I switch from test classes to test functions? I see benefits to using test classes (namespacing, so e.g. we wouldn't have to repeat the class name in every test function name, leaving more room to be more descriptive with the name of the test; classes can be folded in editors), but don't know the benefits of test functions over classes. Happy to learn, and switch if test functions are your preference.
3. The `fget` in `accept_language_property`, like the existing `fget` in `accept_property`, creates a new instance every time. Is that necessary, and might it be good to cache the instance? Most people would probably not expect the header to be re-parsed every time they access `request.accept_language`.
4. I did what I think you might want with the deprecation warnings, but please let me know if you'd like me to change or remove them. Also, calling `warn()` with `DeprecationWarning` and `PendingDeprecationWarning` is now ignored by default from Python version 2.7. I saw quite a few `DeprecationWarning`s in WebOb -- is that an issue?
5. I think I can fix some of the issues in `.quality()` and `.best_match()`, so that they conform to the RFC in how they handle e.g. `q=0` and `*`, but they would still be their own unique algorithms that are not specified or mentioned in the RFCs. (And I'm pretty sure `best_match()` does not implement the matching scheme used in Apache, at least not for `Accept-Language`?) So they are probably not methods you'd want to maintain in the long run -- is it worth fixing those issues when we would like people to move away from them so you can deprecate them?
6. `AcceptLanguageValidHeader`, `AcceptLanguageInvalidHeader`, and `AcceptLanguageNoHeader` all inherit from `AcceptLanguage`, so they can all be identified as an `AcceptLanguage` header. Would it be worth making `AcceptLanguage` an abstract base class and specifying the properties and methods that can be expected in an `AcceptLanguage` (sub)class?
7. What should I do about the `modifier` parameter in `Accept.quality()` and the `default_quality` parameter in `NilAccept.quality()`? (I explained the issues with the `modifier` parameter with comments in `AcceptLanguageValidHeader.quality()` and the `default_quality` parameter is not used at all in `NilAccept.quality`, and does not appear to match any corresponding parameter in `Accept.quality()` either.)

Please let me know if there is anything else you'd like me to change. Thanks!