### PR TITLE
html_use_smartypants is no longer needed because RTD now uses Sphinx …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,8 +58,6 @@ html_static_path = ['_static']
 
 htmlhelp_basename = 'WebObdoc'
 
-html_use_smartypants = False
-
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
…1.6.5