### PR TITLE
MIMEAccept mimics old behaviour better

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,9 @@ Experimental Features
 Bugfix
 ~~~~~~
 
+- acceptparse.MIMEAccept which is deprecated in WebOb 1.8.0 made a backwards
+  incompatible change that led to it raising on an invalid Accept header. This
+  behaviour has now been reversed, as well as some other fixes to allow
+  MIMEAccept to behave more like the old version. See
+  https://github.com/Pylons/webob/pull/356
+


### PR DESCRIPTION
This updates MIMEAccept to mimic old behaviour better so that downstream
projects are not as broken.

The goal is not to provide the exact same behaviour, and thus MIMEAccept
still uses the new Accept header parsing and matching, however it is
much closer to the old API because it no longer raises on an invalid
header vs what was shipped in WebOb 1.8.0.