### PR TITLE
Remove ``key`` kwarg, as it was an oversight.

### DIFF
--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -949,8 +949,7 @@ class Response(object):
 
     def set_cookie(self, name=None, value='', max_age=None,
                    path='/', domain=None, secure=False, httponly=False,
-                   comment=None, expires=None, overwrite=False, key=None,
-                   samesite=None):
+                   comment=None, expires=None, overwrite=False, samesite=None):
         """
         Set (add) a cookie for the response.
 


### PR DESCRIPTION
Also I noted this in the docstring for `set_cookie()`:

```rst
        ``value``

           The cookie value, which should be a string or ``None``.  If
           ``value`` is ``None``, it's equivalent to calling the
           :meth:`webob.response.Response.unset_cookie` method for this
           cookie key (it effectively deletes the cookie on the client).
```

Should that last line be "cookie *name*"?