### PR TITLE
Bugfix: non-bytes samesite

### DIFF
--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -239,6 +239,8 @@ def serialize_cookie_date(v):
 
 
 def serialize_samesite(v):
+    v = bytes_(v)
+
     if v.lower() not in (b"strict", b"lax"):
         raise ValueError("SameSite must be b'Strict' or b'Lax'")
     return v

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -242,7 +242,7 @@ def serialize_samesite(v):
     v = bytes_(v)
 
     if v.lower() not in (b"strict", b"lax"):
-        raise ValueError("SameSite must be b'Strict' or b'Lax'")
+        raise ValueError("SameSite must be 'Strict' or 'Lax'")
     return v
 
 

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -471,8 +471,8 @@ def make_cookie(name, value, max_age=None, path='/', domain=None,
       Set a comment on the cookie. Default: ``None``
 
     ``samesite``
-      The 'SameSite' attribute of the cookie, can be either ``b"Strict"``,
-      ``b"Lax"``, or ``None``.
+      The 'SameSite' attribute of the cookie, can be either ``"Strict"``,
+      ``"Lax"``, or ``None``.
     """
 
     # We are deleting the cookie, override max_age and expires

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -1005,7 +1005,7 @@ class Response(object):
 
           A string representing the ``SameSite`` attribute of the cookie or
           ``None``. If samesite is ``None`` no ``SameSite`` value will be sent
-          in the cookie. Should only be ``b"Strict"`` or ``b"Lax"``.
+          in the cookie. Should only be ``"Strict"`` or ``"Lax"``.
 
         ``comment``
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -450,6 +450,13 @@ class TestCookieMakeCookie(object):
         assert 'test_cookie=value' in cookie
         assert 'Path=/foo/bar/baz' in cookie
 
+    @pytest.mark.parametrize("samesite", ["Strict", "Lax"])
+    def test_make_cookie_samesite(self, samesite):
+        cookie = self.makeOne('test_cookie', 'value', samesite=samesite)
+
+        assert 'test_cookie=value' in cookie
+        assert 'SameSite=' + samesite in cookie
+
 class CommonCookieProfile(object):
     def makeDummyRequest(self, **kw):
         class Dummy(object):
@@ -661,12 +668,20 @@ class TestSignedCookieProfile(CommonCookieProfile):
             assert '; HttpOnly' in cookie[1]
 
     @pytest.mark.parametrize("samesite", [b"Strict", b"Lax"])
+    def test_with_samesite_bytes(self, samesite):
+        cookie = self.makeOne(samesite=samesite)
+        ret = cookie.get_headers("test")
+
+        for cookie in ret:
+            assert "; SameSite=" + samesite.decode('ascii') in cookie[1]
+
+    @pytest.mark.parametrize("samesite", ["Strict", "Lax"])
     def test_with_samesite(self, samesite):
         cookie = self.makeOne(samesite=samesite)
         ret = cookie.get_headers("test")
 
         for cookie in ret:
-            assert "; SameSite=" + samesite.decode("ascii") in cookie[1]
+            assert "; SameSite=" + samesite in cookie[1]
 
     def test_cookie_length(self):
         cookie = self.makeOne()


### PR DESCRIPTION
Correctly coerce non-bytes to bytes when serializing `SameSite` so that it's use matches that of the other parameters allowed by `Response.set_cookie` and `cookies.make_cookie`.

Closes https://github.com/Pylons/webob/issues/361
Related https://github.com/Pylons/webob/pull/362