### PR TITLE
use collections.abc for abc types if available

### DIFF
--- a/src/webob/compat.py
+++ b/src/webob/compat.py
@@ -49,6 +49,11 @@ try:
 except ImportError:
     from Queue import Queue, Empty
 
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 if PY3:
     from urllib import parse
     urlparse = parse

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -16,6 +16,7 @@ import time
 import warnings
 
 from webob.compat import (
+    MutableMapping,
     PY2,
     text_type,
     bytes_,
@@ -31,7 +32,7 @@ __all__ = ['Cookie', 'CookieProfile', 'SignedCookieProfile', 'SignedSerializer',
 
 _marker = object()
 
-class RequestCookies(collections.MutableMapping):
+class RequestCookies(MutableMapping):
 
     _cache_key = 'webob._parsed_cookies'
 

--- a/src/webob/headers.py
+++ b/src/webob/headers.py
@@ -1,5 +1,5 @@
-from collections import MutableMapping
 from webob.compat import (
+    MutableMapping,
     iteritems_,
     string_types,
     )

--- a/src/webob/multidict.py
+++ b/src/webob/multidict.py
@@ -4,12 +4,11 @@
 """
 Gives a multi-value dictionary object (MultiDict) plus several wrappers
 """
-from collections import MutableMapping
-
 import binascii
 import warnings
 
 from webob.compat import (
+    MutableMapping,
     PY2,
     iteritems_,
     itervalues_,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import collections
 import sys
 import warnings
 
@@ -26,6 +25,7 @@ from webob.acceptparse import (
     AcceptValidHeader,
     )
 from webob.compat import (
+    MutableMapping,
     bytes_,
     native_,
     text_type,
@@ -3415,7 +3415,7 @@ class TestRequest_functional(object):
 
         # Cookies
         req.headers['Cookie'] = 'test=value'
-        assert isinstance(req.cookies, collections.MutableMapping)
+        assert isinstance(req.cookies, MutableMapping)
         assert list(req.cookies.items()) == [('test', 'value')]
         req.charset = None
         assert req.cookies == {'test': 'value'}


### PR DESCRIPTION
`collections.MutableMapping` and other abc types were deprecated in 3.3 and will be removed in 3.8