### PR TITLE
Support for Accept specificity

### DIFF
--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1008,7 +1008,7 @@ class AcceptValidHeader(Accept):
         acceptable_offers_n_quality_factors.sort(key=lambda tuple_: tuple_[2])
         # (stable) sort by qvalue and then specificity, descending
         acceptable_offers_n_quality_factors.sort(
-            key=lambda tuple_: (tuple_[1], tuple_[3], reverse=True
+            key=lambda tuple_: (tuple_[1], tuple_[3]), reverse=True
         )
         # drop offer_index, specificity
         acceptable_offers_n_quality_factors = [

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -1006,13 +1006,9 @@ class AcceptValidHeader(Accept):
         ]
         # sort by offer_index, ascending
         acceptable_offers_n_quality_factors.sort(key=lambda tuple_: tuple_[2])
-        # (stable) sort by specificity, descending
+        # (stable) sort by qvalue and then specificity, descending
         acceptable_offers_n_quality_factors.sort(
-            key=lambda tuple_: tuple_[3], reverse=True
-        )
-        # (stable) sort by qvalue, descending
-        acceptable_offers_n_quality_factors.sort(
-            key=lambda tuple_: tuple_[1], reverse=True
+            key=lambda tuple_: (tuple_[1], tuple_[3], reverse=True
         )
         # drop offer_index, specificity
         acceptable_offers_n_quality_factors = [

--- a/src/webob/acceptparse.py
+++ b/src/webob/acceptparse.py
@@ -993,8 +993,9 @@ class AcceptValidHeader(Accept):
                 )
 
         acceptable_offers_n_quality_factors = [
-            # key is offer, value[0] is qvalue, value[1] is offer_index
-            (key, value[0], value[1])
+            # key is offer, value[0] is qvalue, value[1] is offer_index,
+            # value[2] is specificity
+            (key, value[0], value[1], value[2])
             for key, value in acceptable_offers_n_quality_factors.items()
             if value[0]  # != 0.0
             # We have to filter out the offers with qvalues of 0 here instead
@@ -1005,11 +1006,15 @@ class AcceptValidHeader(Accept):
         ]
         # sort by offer_index, ascending
         acceptable_offers_n_quality_factors.sort(key=lambda tuple_: tuple_[2])
+        # (stable) sort by specificity, descending
+        acceptable_offers_n_quality_factors.sort(
+            key=lambda tuple_: tuple_[3], reverse=True
+        )
         # (stable) sort by qvalue, descending
         acceptable_offers_n_quality_factors.sort(
             key=lambda tuple_: tuple_[1], reverse=True
         )
-        # drop offer_index
+        # drop offer_index, specificity
         acceptable_offers_n_quality_factors = [
             (item[0], item[1]) for item in acceptable_offers_n_quality_factors
         ]

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1162,6 +1162,8 @@ class TestAcceptValidHeader(object):
             ),
             ("*/*", ["text/*"], []),
             ("", ["text/*", "*/*", "text/html", "text/html;level=1", "image/*"], []),
+            ("application/json, */*", ["text/html", "application/json"],
+             [("application/json", 1.0), ("text/html", 1.0)]),
         ],
     )
     def test_acceptable_offers__valid_offers(

--- a/tests/test_acceptparse.py
+++ b/tests/test_acceptparse.py
@@ -1162,8 +1162,11 @@ class TestAcceptValidHeader(object):
             ),
             ("*/*", ["text/*"], []),
             ("", ["text/*", "*/*", "text/html", "text/html;level=1", "image/*"], []),
-            ("application/json, */*", ["text/html", "application/json"],
-             [("application/json", 1.0), ("text/html", 1.0)]),
+            (
+                "application/json, */*",
+                ["text/html", "application/json"],
+                [("application/json", 1.0), ("text/html", 1.0)],
+            ),
         ],
     )
     def test_acceptable_offers__valid_offers(

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2621,8 +2621,8 @@ class TestRequest_functional(object):
         ]
         req = self._blankOne("/", accept=["text/plain", "message/*"])
         assert fut(req, ["message/x-foo", "text/plain"]) == [
-            ("message/x-foo", 1.0),
             ("text/plain", 1.0),
+            ("message/x-foo", 1.0),
         ]
         assert fut(req, ["text/plain", "message/x-foo"]) == [
             ("text/plain", 1.0),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2612,8 +2612,8 @@ class TestRequest_functional(object):
         assert req.accept
         req = self._blankOne("/", accept=["*/*", "text/*"])
         assert fut(req, ["application/x-foo", "text/plain"]) == [
-            ("application/x-foo", 1.0),
             ("text/plain", 1.0),
+            ("application/x-foo", 1.0),
         ]
         assert fut(req, ["text/plain", "application/x-foo"]) == [
             ("text/plain", 1.0),


### PR DESCRIPTION
In the case that clients send "Accept" header fields that indicate a
preferential response media type, the acceptable_offers function was
dropping the preference.

This change introduces a stable sort on specificity, as well as normal
ordering. This is accompanied by a new test.