### PR TITLE
Update travis link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 WebOb
 =====
 
-.. image:: https://travis-ci.org/Pylons/webob.png?branch=master
+.. image:: https://travis-ci.com/Pylons/webob.png?branch=master
         :target: https://travis-ci.org/Pylons/webob
 
 .. image:: https://readthedocs.org/projects/webob/badge/?version=stable

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ WebOb
 =====
 
 .. image:: https://travis-ci.com/Pylons/webob.png?branch=master
-        :target: https://travis-ci.org/Pylons/webob
+        :target: https://travis-ci.com/Pylons/webob
 
 .. image:: https://readthedocs.org/projects/webob/badge/?version=stable
         :target: https://docs.pylonsproject.org/projects/webob/en/stable/


### PR DESCRIPTION
The current travis-ci link in the README.rst links to `.org`. Since travis has migrated to `.com` this causes the image to break. This PR resolves this.