### PR TITLE
Fixing decode error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ WebOb.egg-info/
 pytest*.xml
 coverage*.xml
 .pytest_cache/
+.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ WebOb.egg-info/
 pytest*.xml
 coverage*.xml
 .pytest_cache/
-.idea/
 

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -623,7 +623,7 @@ class Response(object):
         body = self.body
         try:
             return body.decode(decoding, self.unicode_errors)
-        except:
+        except UnicodeDecodeError:
             return body.decode("UTF-8", self.unicode_errors)
 
     def _text__set(self, value):

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -621,7 +621,10 @@ class Response(object):
             )
         decoding = self.charset or self.default_body_encoding
         body = self.body
-        return body.decode(decoding, self.unicode_errors)
+        try:
+            return body.decode(decoding, self.unicode_errors)
+        except:
+            return body.decode("UTF-8", self.unicode_errors)
 
     def _text__set(self, value):
         if not self.charset and not self.default_body_encoding:

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -623,7 +623,7 @@ class Response(object):
         body = self.body
         try:
             return body.decode(decoding, self.unicode_errors)
-        except UnicodeEncodeError:
+        except UnicodeDecodeError:
             return body.decode("UTF-8", self.unicode_errors)
 
     def _text__set(self, value):

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -623,7 +623,7 @@ class Response(object):
         body = self.body
         try:
             return body.decode(decoding, self.unicode_errors)
-        except UnicodeDecodeError:
+        except UnicodeEncodeError:
             return body.decode("UTF-8", self.unicode_errors)
 
     def _text__set(self, value):


### PR DESCRIPTION
Fixing issue with UTF-8 strings when 
```
decoding = self.charset or self.default_body_encoding
```
passes the wrong decoding option.