### PR TITLE
disable validating the SameSite value, if/when the cookie spec changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,20 @@ Feature
   See https://github.com/Pylons/webob/pull/376 and
   https://github.com/Pylons/webob/pull/379
 
+ - Validation of SameSite values can be disabled by toggling a module flag. This
+   is in anticipation of future changes in evolving cookie standards.
+   The discussion in https://github.com/Pylons/webob/pull/407 (which initially
+   expanded the allowed options) notes the sudden change to browser cookie
+   implementation details may happen again.
+
+   In May 2019, Google announced a new model for privacy controls in their
+   browsers, which affected the list fo valid options for the SameSite attribute
+   of cookies. In late 2019, the company began to roll out these changes to their
+   browsers to force developer adoption of the new specification.
+   See https://www.chromium.org/updates/same-site and
+   https://blog.chromium.org/2019/10/developers-get-ready-for-new.html for more
+   details on this change.
+
 Compatibility
 ~~~~~~~~~~~~~
 

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -33,6 +33,10 @@ __all__ = [
 
 _marker = object()
 
+# Module flag to handle validation of SameSite attributes
+# See the documentation for ``make_cookie`` for more information.
+SAMESITE_VALIDATION = True
+
 
 class RequestCookies(MutableMapping):
 
@@ -277,8 +281,9 @@ def serialize_cookie_date(v):
 def serialize_samesite(v):
     v = bytes_(v)
 
-    if v.lower() not in (b"strict", b"lax", b"none"):
-        raise ValueError("SameSite must be 'strict', 'lax', or 'none'")
+    if SAMESITE_VALIDATION:
+        if v.lower() not in (b"strict", b"lax", b"none"):
+            raise ValueError("SameSite must be 'strict', 'lax', or 'none'")
 
     return v
 
@@ -553,7 +558,18 @@ def make_cookie(
 
     ``samesite``
       The 'SameSite' attribute of the cookie, can be either ``"strict"``,
-      ``"lax"``, ``"none"``, or ``None``.
+      ``"lax"``, ``"none"``, or ``None``. By default, WebOb will validate the
+      value to ensure it conforms to the allowable options in the active Cookie
+      RFC.
+
+      To disable this check and send headers that are experimental or introduced
+      in a future RFC, set the module flag ``SAMESITE_VALIDATION`` to a
+      false value like::
+
+        import webob.cookies
+        webob.cookies.SAMESITE_VALIDATION = False
+
+        ck = webob.cookies.make_cookie(cookie_name, value, samesite='future')
     """
 
     # We are deleting the cookie, override max_age and expires

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -122,6 +122,7 @@ def test_cookie_samesite_none_not_secure():
     with pytest.raises(ValueError):
         c.serialize()
 
+
 def test_cookie_samesite_future():
     # first default
     c = cookies.Cookie()

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -122,6 +122,36 @@ def test_cookie_samesite_none_not_secure():
     with pytest.raises(ValueError):
         c.serialize()
 
+def test_cookie_samesite_future():
+    # first default
+    c = cookies.Cookie()
+    with pytest.raises(ValueError) as excinfo:
+        c[b"foo"] = b"bar"
+        c[b"foo"].samesite = b"Future"
+        c.serialize()
+    assert excinfo.value.args[0] == "SameSite must be 'strict', 'lax', or 'none'"
+
+    try:
+        # disable validation so future args pass
+        cookies.SAMESITE_VALIDATION = False
+        c = cookies.Cookie()
+        c[b"foo"] = b"bar"
+        c[b"foo"].samesite = b"Future"
+        assert c.serialize() == "foo=bar; SameSite=Future"
+
+        # reset to the default behavior pass
+        cookies.SAMESITE_VALIDATION = True
+        c = cookies.Cookie()
+        with pytest.raises(ValueError) as excinfo:
+            c[b"foo"] = b"bar"
+            c[b"foo"].samesite = b"Future"
+            c.serialize()
+        assert excinfo.value.args[0] == "SameSite must be 'strict', 'lax', or 'none'"
+
+    except Exception as exc:
+        cookies.SAMESITE_VALIDATION = True
+        raise
+
 
 def test_cookie_reserved_keys():
     c = cookies.Cookie("dismiss-top=6; CP=null*; $version=42; a=42")


### PR DESCRIPTION
PR #407 expanding the list of allowable SameSite values to included the string `"None"`.

This PR introduces a module flag `SAMESITE_VALIDATION` to bypass this check if/when the cookie specification or major browser implementations change again:

        import webob.cookies
        webob.cookies.SAMESITE_VALIDATION = False

        ck = webob.cookies.make_cookie(cookie_name, value, samesite='future')
