### PR TITLE
Remove deprecated isAlive method

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def serve():
             log.debug("shutting server down")
             server.shutdown()
             worker.join(1)
-            if worker.isAlive():
+            if worker.is_alive():
                 log.warning("worker is hanged")
             else:
                 log.debug("server stopped")


### PR DESCRIPTION
`threading.Thread.isAlive` is deprecated in Python 3.8, and removed entirely in Python 3.9.  The alternative `is_alive` is available since Python 2.6.

https://bugs.python.org/issue37804