### PR TITLE
Rewind body_file_raw after parsing in POST

### DIFF
--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -810,6 +810,7 @@ class BaseRequest(object):
                 encoding="utf8",
             )
 
+        self.body_file_raw.seek(0)
         vars = MultiDict.from_fieldstorage(fs)
         env["webob._parsed_post_vars"] = (vars, self.body_file_raw)
         return vars

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -613,6 +613,21 @@ class TestRequestCommon(object):
         assert bar.filename == "bar.txt"
         assert bar.file.read() == b'these are the contents of the file "bar.txt"\n'
 
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+    def test_POST_preserves_body_file(self, method):
+        data = b"var1=value1&var2=value2&rep=1&rep=2"
+        wsgi_input = BytesIO(data)
+        environ = {
+            "wsgi.input": wsgi_input,
+            "REQUEST_METHOD": method,
+            "CONTENT_LENGTH": len(data),
+            "CONTENT_TYPE": "application/x-www-form-urlencoded",
+        }
+        req = self._makeOne(environ)
+        result = req.POST
+        assert result["var1"] == "value1"
+        assert req.body_file_raw.read() == data
+
     # GET
     def test_GET_reflects_query_string(self):
         environ = {"QUERY_STRING": "foo=123"}


### PR DESCRIPTION
Currently, request.POST reads from `wsgi.input` without rewinding the stream on a `webob._parsed_post_vars` cache miss. This means that WSGI middlewares using WebOb could incidentally prevent a downstream WSGI application from obtaining the raw request body if it uses a different framework.

Here, we seek the raw body file back to its start after cgi parses it.

I've included a test that captures the desired behavior, which fails without the new change. If this is an unreasonable use case or intentional behavior, I'd love to learn more about it. Thanks in advance.
