### PR TITLE
add return value to Response.write

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,7 +85,7 @@ Bugfix
   ``AcceptValidHeader`` and returned them as acceptable in the others.
   See https://github.com/Pylons/webob/pull/372
 
-- ``Response.body_file.write`` and ``Response.write`` now returns the wrote
+- ``Response.body_file.write`` and ``Response.write`` now returns the written
   length. See https://github.com/Pylons/webob/pull/422
 
 Warnings

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,6 +85,9 @@ Bugfix
   ``AcceptValidHeader`` and returned them as acceptable in the others.
   See https://github.com/Pylons/webob/pull/372
 
+- ``Response.body_file.write`` and ``Response.write`` now returns the wrote
+  length. See https://github.com/Pylons/webob/pull/422
+
 Warnings
 ~~~~~~~~
 

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -677,6 +677,7 @@ class Response(object):
                 msg = "You can only write text to Response if charset has " "been set"
                 raise TypeError(msg)
             text = text.encode(self.charset)
+        text_len = len(text)
         app_iter = self._app_iter
         if not isinstance(app_iter, list):
             try:
@@ -687,7 +688,8 @@ class Response(object):
             self.content_length = sum(len(chunk) for chunk in app_iter)
         app_iter.append(text)
         if self.content_length is not None:
-            self.content_length += len(text)
+            self.content_length += text_len
+        return text_len
 
     #
     # app_iter

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -638,7 +638,7 @@ def test_app_iter_range_starts_after_iter_end():
 def test_resp_write_app_iter_non_list():
     res = Response(app_iter=(b"a", b"b"))
     assert res.content_length is None
-    res.write(b"c")
+    assert res.write(b"c") == 1
     assert res.body == b"abc"
     assert res.content_length == 3
 
@@ -675,7 +675,7 @@ def test_response_file_body_tell_text():
 
     rbo = ResponseBodyFile(Response())
     assert rbo.tell() == 0
-    rbo.write("123456789")
+    assert rbo.write("123456789") == 9
     assert rbo.tell() == 9
 
 
@@ -687,13 +687,13 @@ def test_response_write_non_str():
 
 def test_response_file_body_write_empty_app_iter():
     res = Response("foo")
-    res.write("baz")
+    assert res.write("baz") == 3
     assert res.app_iter == [b"foo", b"baz"]
 
 
 def test_response_file_body_write_empty_body():
     res = Response("")
-    res.write("baz")
+    assert res.write("baz") == 3
     assert res.app_iter == [b"", b"baz"]
 
 
@@ -829,7 +829,7 @@ def test_body_file_del():
 def test_write_unicode():
     res = Response()
     res.text = text_(b"La Pe\xc3\xb1a", "utf-8")
-    res.write(text_(b"a"))
+    assert res.write(text_(b"a")) == 1
     assert res.text, text_(b"La Pe\xc3\xb1aa" == "utf-8")
 
 
@@ -842,7 +842,7 @@ def test_write_unicode_no_charset():
 def test_write_text():
     res = Response()
     res.body = b"abc"
-    res.write(text_(b"a"))
+    assert res.write(text_(b"a")) == 1
     assert res.text == "abca"
 
 
@@ -1272,7 +1272,7 @@ def test_body_file_write_no_charset():
 def test_body_file_write_unicode_encodes():
     s = text_(b"La Pe\xc3\xb1a", "utf-8")
     res = Response()
-    res.write(s)
+    assert res.write(s) == 8
     assert res.app_iter, [b"" == b"La Pe\xc3\xb1a"]
 
 


### PR DESCRIPTION
The `Response.body_file` is described as a file-like object. However, the `write` method does not return the wrote length.