### PR TITLE
backport of #424 (was: deflate'd response: use RFC compliant decompression by default)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,16 @@
+Unreleased
+----------
+
+Bugfix
+~~~~~~
+
+- Decoding deflate-encoded responses now supports data which is packed in
+  a zlib container as it is supposed to be. The old, non-standard behaviour
+  is still supported.
+
+  See https://github.com/Pylons/webob/pull/426
+
+
 1.8.6 (2020-01-21)
 ------------------
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -381,6 +381,18 @@ def test_decode_content_with_deflate():
     assert res.body == body
     assert res.content_encoding is None
 
+def test_decode_content_with_deflate_and_zlib_header():
+    res = Response()
+    body = b"Hey Hey Hey"
+    # don't chop off the zlib container
+    # https://tools.ietf.org/html/rfc7230#section-4.2.2 says
+    # that chopping it exists but is non-conformant
+    res.body = zlib.compress(body)
+    res.content_encoding = "deflate"
+    res.decode_content()
+    assert res.body == body
+    assert res.content_encoding is None
+
 def test_content_length():
     r0 = Response('x' * 10, content_length=10)
 


### PR DESCRIPTION
This is a backport of #424 onto the 1.8-branch as suggested in #425 

[RFC7230](https://tools.ietf.org/html/rfc7230#section-4.2.2) specifies
that

>   The "deflate" coding is a "zlib" data format [RFC1950](https://tools.ietf.org/html/rfc1950) containing a
>   "deflate" compressed data stream [RFC1951](https://tools.ietf.org/html/rfc1951) that uses a combination of
>   the Lempel-Ziv (LZ77) compression algorithm and Huffman coding.

but also

>       Note: Some non-conformant implementations send the "deflate"
>       compressed data without the zlib wrapper.

Thus deflate coded data should be expected to be received within a
"zlib" container, however if no container is present, the data shouldn't
be rejected.

This patch tries to decode that data using RFC7230 conformant decoding
and falls back to unwrapped decoding only if the previous attempt didn't
work.