### PR TITLE
Pass the Request.decode errors argument down to transcode_query

### DIFF
--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -1749,7 +1749,7 @@ class Transcoder:
 
             return q_orig
 
-        q = list(parse_qsl_text(q, self.charset))
+        q = list(parse_qsl_text(q, self.charset, self.errors))
 
         return url_encode(q)
 

--- a/src/webob/util.py
+++ b/src/webob/util.py
@@ -22,7 +22,7 @@ def url_unquote(s):
     return unquote(s.encode("ascii")).decode("latin-1")
 
 
-def parse_qsl_text(qs, encoding="utf-8"):
+def parse_qsl_text(qs, encoding="utf-8", errors="strict"):
     qs = qs.encode("latin-1")
     qs = qs.replace(b"+", b" ")
     pairs = [s2 for s1 in qs.split(b"&") for s2 in s1.split(b";") if s2]
@@ -34,7 +34,7 @@ def parse_qsl_text(qs, encoding="utf-8"):
             nv.append("")
         name = unquote(nv[0])
         value = unquote(nv[1])
-        yield (name.decode(encoding), value.decode(encoding))
+        yield (name.decode(encoding, errors), value.decode(encoding, errors))
 
 
 def text_(s, encoding="latin-1", errors="strict"):


### PR DESCRIPTION
Currently, when calling Request.decode("encoding", "ignore"), webob still raises a decode error with invalid characters despite passing an "ignore" argument to errors. This fix uses the given argument.