### PR TITLE
webob.static.FileApp responds with different content-types for Windows and Linux

### DIFF
--- a/src/webob/static.py
+++ b/src/webob/static.py
@@ -9,7 +9,9 @@ __all__ = [
     'FileApp', 'DirectoryApp',
 ]
 
-mimetypes._winreg = None # do not load mimetypes from windows registry
+# do not load mimetypes from windows registry
+mimetypes._winreg = mimetypes._mimetypes_read_windows_registry = None
+
 mimetypes.add_type('text/javascript', '.js') # stdlib default is application/x-javascript
 mimetypes.add_type('image/x-icon', '.ico') # not among defaults
 


### PR DESCRIPTION
When using `FileApp` the content-type of the response may differ for Windows and Linux.

I tested it using `FileApp("test.map").kw`.

**Issue:**
The mimetypes module is used to determine the mimetype / content-type of the `FileApp`.
`mimetypes._winreg` is set to `None` to prevent loading mimetypes from Windows registry.
Since https://github.com/python/cpython/commit/bbf2fb6c7ae78f40483606f467739a58cd747270 the mimetypes module uses the `winapi `and `winreg `to load the mimetypes from the registry.

You probably want to set `_mimetypes_read_windows_registry = None` as well.