### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,7 +21,6 @@ jobs:
                     - "3.10"
                     - "3.11"
                     - "3.12"
-                    - "pypy-3.8"
                     - "pypy-3.9"
                     - "pypy-3.10"
                 os:
@@ -29,8 +28,6 @@ jobs:
                     - "windows-latest"
                     - "macos-latest"
                 include:
-                  - py: "pypy-3.8"
-                    toxenv: "pypy38"
                   - py: "pypy-3.9"
                     toxenv: "pypy39"
                   - py: "pypy-3.10"
@@ -38,10 +35,6 @@ jobs:
                 exclude:
                     # Don't run all PyPy versions except latest on
                     # Windows/macOS. They are expensive to run.
-                    - os: "windows-latest"
-                      py: "pypy-3.8"
-                    - os: "macos-latest"
-                      py: "pypy-3.8"
                     - os: "windows-latest"
                       py: "pypy-3.9"
                     - os: "macos-latest"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,9 +28,6 @@ jobs:
                     - "ubuntu-latest"
                     - "windows-latest"
                     - "macos-latest"
-                architecture:
-                    - x64
-                    - x86
                 include:
                   - py: "pypy-3.8"
                     toxenv: "pypy38"
@@ -39,11 +36,6 @@ jobs:
                   - py: "pypy-3.10"
                     toxenv: "pypy310"
                 exclude:
-                    # Linux and macOS don't have x86 python
-                    - os: "ubuntu-latest"
-                      architecture: x86
-                    - os: "macos-latest"
-                      architecture: x86
                     # Don't run all PyPy versions except latest on
                     # Windows/macOS. They are expensive to run.
                     - os: "windows-latest"
@@ -63,7 +55,6 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.py }}
-                  architecture: ${{ matrix.architecture }}
             - run: pip install tox
             - name: Running tox with specific toxenv
               if: ${{ matrix.toxenv != '' }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py38,py39,py310,py311,py312,pypy38,pypy39,pypy310,
+    py38,py39,py310,py311,py312,pypy39,pypy310,
     coverage,
     docs,
 isolated_build = True
@@ -10,7 +10,6 @@ isolated_build = True
 commands =
     python --version
     python -m pytest \
-    pypy38: --no-cov \
     pypy39: --no-cov \
     pypy310: --no-cov \
         {posargs:}


### PR DESCRIPTION
Several Github Actions builds were broken, so I made some changes to get green lights:

MacOS builds were failing because architecture was x64 but `macos-latest` is now M1 machines (arm64).  I decided to remove architecture from the matrix entirely.  x86 is already disabled for Linux and MacOS, it only runs on Windows, so I don't know how useful it is.

Alternative solutions:  Use `macos-13`, which is an x64 runner.  Or expand the architecture matrix so we can run tests across Windows x86, Windows x64, Linux x64, and MacOS arm64.

PyPy3.8 builds were failing because of a segfault during pytests.  This [issue has been resolved](https://pypy.org/posts/2024/03/fixing-bug-incremental-gc.html), but because pypy3.8 is no longer actively supported only pypy3.9 and 3.10 have been fixed.  Because it's no longer supported, I think it's reasonable to remove entirely.