### PR TITLE
Backport `legacy-cgi` to 1.8 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
     packages=find_packages('src', exclude=['tests']),
     package_dir={'': 'src'},
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    install_requires=[
+        "legacy-cgi>=2.6; python_version>='3.13'",
+    ],
     zip_safe=True,
     extras_require={
         'testing': testing_extras,


### PR DESCRIPTION
Backport of #467

Unfortunate 1.8 is significantly behind the main branch re CI:  Latest tested version is Python 3.7 (!!) and there's no Github Actions.  Doesn't seem much point trying to backport that so I didn't bother.  I did however confirm tests do pass in Python 3.13.


[tox-py313.txt](https://github.com/user-attachments/files/17337305/tox-py313.txt)
