### PR TITLE
docs,tests: update contributing running tests section

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,6 @@ source =
 [report]
 show_missing = true
 precision = 2
+
+[html]
+show_contexts = True

--- a/contributing.md
+++ b/contributing.md
@@ -41,17 +41,23 @@ supported systems and attempt to build the docs.
 
 For example, to run the test suite with your current Python runtime:
 
-    tox -e py
+```shell
+tox -e py
+```
 
 If you wish to run multiple targets, you can do so by separating them with a
 comma:
 
-    tox -e py312,coverage
+```shell
+tox -e py312,coverage
+```
 
 If you've already run the coverage target and want to see the results in HTML,
 you can override `tox.ini` settings with the `commands` option:
 
-    tox -e coverage -x testenv:coverage.commands="coverage html"
+```shell
+tox -e coverage -x testenv:coverage.commands="coverage html"
+```
 
 To build the docs:
 

--- a/contributing.md
+++ b/contributing.md
@@ -55,11 +55,15 @@ you can override `tox.ini` settings with the `commands` option:
 
 To build the docs:
 
-    tox -e docs
+```shell
+tox -e docs
+```
 
 List all possible targets:
 
-    tox list # or `tox l`
+```shell
+tox list # or `tox l`
+```
 
 See `tox.ini` file for details, or <https://tox.wiki/> for general `tox` usage.
 

--- a/contributing.md
+++ b/contributing.md
@@ -36,20 +36,32 @@ one or two development branches are actively maintained.
 Running Tests
 -------------
 
-*Note:* This section needs better instructions.
-
 Run `tox` from within your checkout. This will run the tests across all
 supported systems and attempt to build the docs.
 
-To run the tests for Python 2.x only:
+For example, to run the test suite with your current Python runtime:
 
-    $ tox py2-cover
+    tox -e py
 
-To build the docs for Python 3.x only:
+If you wish to run multiple targets, you can do so by separating them with a
+comma:
 
-    $ tox py3-docs
+    tox -e py312,coverage
 
-See the `tox.ini` file for details.
+If you've already run the coverage target and want to see the results in HTML,
+you can override `tox.ini` settings with the `commands` option:
+
+    tox -e coverage -x testenv:coverage.commands="coverage html"
+
+To build the docs:
+
+    tox -e docs
+
+List all possible targets:
+
+    tox list # or `tox l`
+
+See `tox.ini` file for details, or <https://tox.wiki/> for general `tox` usage.
 
 
 Building documentation for a Pylons Project project

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ license_file = docs/license.txt
 python_files = test_*.py
 testpaths =
     tests
-addopts = -W always --cov --cov-report=term-missing
+addopts = -W always --cov --cov-context=test --cov-report=term-missing


### PR DESCRIPTION
- Remove Python 2.x instructions
- Use correct modern targets
- record test contexts to output, refs: https://pytest-cov.readthedocs.io/en/stable/contexts.html