### PR TITLE
Replace to-be-deprecated utcnow() datetime calls with aware now() calls

### DIFF
--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 from collections.abc import MutableMapping
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import hashlib
 import hmac
 import json
@@ -239,10 +239,13 @@ def serialize_cookie_date(v):
         v = timedelta(seconds=v)
 
     if isinstance(v, timedelta):
-        v = datetime.utcnow() + v
+        v = datetime.now(tz=timezone.utc) + v
 
-    if isinstance(v, (datetime, date)):
+    if isinstance(v, datetime):
+        v = v.astimezone(timezone.utc).timetuple()
+    elif isinstance(v, date):
         v = v.timetuple()
+
     r = time.strftime("%%s, %d-%%s-%Y %H:%M:%S GMT", v)
 
     return bytes_(r % (weekdays[v[6]], months[v[1]]), "ascii")

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import md5
 import re
 import struct
@@ -1246,6 +1246,8 @@ class Response:
             seconds = timedelta_to_seconds(seconds)
         cache_control = self.cache_control
 
+        utcnow = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
         if seconds is None:
             pass
         elif not seconds:
@@ -1259,15 +1261,15 @@ class Response:
             cache_control.max_age = 0
             cache_control.post_check = 0
             cache_control.pre_check = 0
-            self.expires = datetime.utcnow()
+            self.expires = utcnow
 
             if "last-modified" not in self.headers:
-                self.last_modified = datetime.utcnow()
+                self.last_modified = utcnow
             self.pragma = "no-cache"
         else:
             cache_control.properties.clear()
             cache_control.max_age = seconds
-            self.expires = datetime.utcnow() + timedelta(seconds=seconds)
+            self.expires = utcnow + timedelta(seconds=seconds)
             self.pragma = None
 
         for name, value in kw.items():


### PR DESCRIPTION
As per issue https://github.com/Pylons/webob/issues/473

I didn’t add tests yet, see my comments below. ~Still need to format the code, but it looks like Windows tests fail because, I suspect, of [this data source discrepancy](https://docs.python.org/3.13/library/zoneinfo.html#data-sources).~