### PR TITLE
UTF-8 encoded data should not by encoded with latin-1

### DIFF
--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -114,7 +114,7 @@ class BaseRequest:
             return val
         encoding = getattr(self, encattr)
 
-        if encoding in _LATIN_ENCODINGS:  # shortcut
+        if encoding in _LATIN_ENCODINGS or encoding == 'UTF-8':  # shortcut
             return val
 
         return bytes_(val, "latin-1").decode(encoding)


### PR DESCRIPTION
I had problems non ascii letters like umlauts and ß in the requests url path, even though they where uri encoded and also decoded properly before the latin-1 encode step in line 120.
I know this might be a naive fix, maybe you can come up with a better overall approach or guide me towards it. I also don't know if utf-8 encoded uris are out of scope for this library. 