### PR TITLE
Fix assertion in `test_merge_cookies_resp_is_wsgi_callable`

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1052,7 +1052,7 @@ def test_merge_cookies_resp_is_wsgi_callable():
     environ = {}
 
     def dummy_start_response(status, headers, exc_info=None):
-        assert headers, [("Set-Cookie" == "a=1; Path=/")]
+        assert headers == [("Set-Cookie", "a=1; Path=/")]
 
     result = wsgiapp(environ, dummy_start_response)
     assert result == "abc"


### PR DESCRIPTION
[As pointed out](https://github.com/Pylons/webob/pull/466#discussion_r2039851484) by @merwok, this assertion didn't make much sense.  This changes the test so the `Set-Cookie` header is actually checked.