### PR TITLE
Replace deprecated datetime.datetime.utcnow

### DIFF
--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -10,6 +10,7 @@ import string
 import time
 import warnings
 
+from webob.datetime_utils import utcnow
 from webob.util import bytes_, text_
 
 __all__ = [
@@ -239,7 +240,7 @@ def serialize_cookie_date(v):
         v = timedelta(seconds=v)
 
     if isinstance(v, timedelta):
-        v = datetime.utcnow() + v
+        v = utcnow() + v
 
     if isinstance(v, (datetime, date)):
         v = v.timetuple()

--- a/src/webob/datetime_utils.py
+++ b/src/webob/datetime_utils.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import date, datetime, timedelta, tzinfo
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from email.utils import formatdate, mktime_tz, parsedate_tz
 import time
 
@@ -19,6 +19,7 @@ __all__ = [
     "serialize_date",
     "parse_date_delta",
     "serialize_date_delta",
+    "utcnow",
 ]
 
 _now = datetime.now  # hook point for unit tests
@@ -121,3 +122,10 @@ def serialize_date_delta(value):
         return str(int(value))
     else:
         return serialize_date(value)
+
+
+def utcnow():
+    """
+    replacement of deprecated datetime.datetime.utcnow
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import timedelta
 from hashlib import md5
 import re
 import struct
@@ -14,6 +14,7 @@ from webob.datetime_utils import (
     parse_date_delta,
     serialize_date_delta,
     timedelta_to_seconds,
+    utcnow,
 )
 from webob.descriptors import (
     CHARSET_RE,
@@ -1259,15 +1260,15 @@ class Response:
             cache_control.max_age = 0
             cache_control.post_check = 0
             cache_control.pre_check = 0
-            self.expires = datetime.utcnow()
+            self.expires = utcnow()
 
             if "last-modified" not in self.headers:
-                self.last_modified = datetime.utcnow()
+                self.last_modified = utcnow()
             self.pragma = "no-cache"
         else:
             cache_control.properties.clear()
             cache_control.max_age = seconds
-            self.expires = datetime.utcnow() + timedelta(seconds=seconds)
+            self.expires = utcnow() + timedelta(seconds=seconds)
             self.pragma = None
 
         for name, value in kw.items():


### PR DESCRIPTION
The utcnow function was deprecated in Python 3.12[1].

Note that all datetime instances are kept non-timezone-aware to keep backword-compatibility.

[1] https://docs.python.org/3.13/library/datetime.html#datetime.datetime.utcnow