### PR TITLE
Fix test to stop lint error.

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1052,7 +1052,7 @@ def test_merge_cookies_resp_is_wsgi_callable():
     environ = {}
 
     def dummy_start_response(status, headers, exc_info=None):
-        assert headers, [("Set-Cookie" == "a=1; Path=/")]
+        assert headers == [("Set-Cookie", "a=1; Path=/")]
 
     result = wsgiapp(environ, dummy_start_response)
     assert result == "abc"


### PR DESCRIPTION
Seems that the linter was catching this by trying to strip the parens and its blocking the docs build.
Looks like the test itself was incorrectly a no-op in the first place?
