### PR TITLE
Handle buffered reads before disconnect

### DIFF
--- a/src/webob/request.py
+++ b/src/webob/request.py
@@ -1628,11 +1628,13 @@ class LimitedLengthFile(io.RawIOBase):
         if not self.remaining:
             return 0
         sz0 = min(len(buff), self.remaining)
+        if not sz0:
+            return 0
         data = self.file.read(sz0)
         sz = len(data)
         self.remaining -= sz
 
-        if sz < sz0 and self.remaining:
+        if not data and self.remaining:
             raise DisconnectionError(
                 "The client disconnected while sending the body "
                 "(%d more bytes were expected)" % (self.remaining,)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping
-from io import BytesIO, StringIO
+from io import BufferedReader, BytesIO, StringIO
 import sys
 import warnings
 
@@ -2965,6 +2965,30 @@ class TestLimitedLengthFile:
         dummyfile = DummyFile()
         inst = self._makeOne(dummyfile, 0)
         assert inst.fileno() == 1
+
+    def test_short_read_with_data_returns_before_disconnect(self):
+        inst = self._makeOne(BytesIO(b"abc"), 5)
+        buff = bytearray(4)
+
+        assert inst.readinto(buff) == 3
+        assert buff[:3] == b"abc"
+
+        with pytest.raises(OSError):
+            inst.readinto(buff)
+
+    def test_zero_length_readinto_buffer(self):
+        inst = self._makeOne(BytesIO(b"abc"), 5)
+
+        assert inst.readinto(bytearray()) == 0
+        assert inst.remaining == 5
+
+    def test_buffered_readline_returns_line_before_disconnect(self):
+        inst = BufferedReader(self._makeOne(BytesIO(b"a=b\nz="), 100))
+
+        assert inst.readline() == b"a=b\n"
+
+        with pytest.raises(OSError):
+            inst.readline()
 
 
 class Test_environ_from_url:


### PR DESCRIPTION
Fixes #479

Summary:
- allow LimitedLengthFile.readinto() to return already-read partial data before reporting a disconnect
- add unit coverage for direct short reads and buffered readline preserving the first line before disconnect

Tests:
- Not run locally
- git diff --check
- GitHub Actions: Build and test, run 26413094955