### PR TITLE
Replace deprecated utcnow() and fix UTC-based timedelta date headers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -120,6 +120,16 @@ Bugfix
   wall-clock time out as GMT. Naive datetimes continue to be treated as UTC.
   See https://github.com/Pylons/webob/pull/475
 
+- Date headers computed from a ``timedelta`` are now based on UTC instead of
+  naive local time. ``webob.datetime_utils`` added the delta to
+  ``datetime.datetime.now()``, which is local, and the result was then
+  serialized as GMT, so the value was off by the machine's UTC offset. This
+  affected setting a header via a ``timedelta`` (such as ``Response.expires``)
+  and reading back a delta-seconds header (such as ``Response.retry_after``).
+  ``Response.cache_expires`` was already correct. See
+  https://github.com/Pylons/webob/issues/430 and
+  https://github.com/Pylons/webob/pull/491
+
 - Response.content_type now accepts unicode strings on Python 2 and encodes
   them to latin-1. See https://github.com/Pylons/webob/pull/389 and
   https://github.com/Pylons/webob/issues/388

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -68,6 +68,13 @@ Feature
 Compatibility
 ~~~~~~~~~~~~~
 
+- Replace the uses of ``datetime.datetime.utcnow()``, which is deprecated as of
+  Python 3.12, with a ``webob.datetime_utils.utcnow()`` helper built on
+  ``datetime.datetime.now(datetime.timezone.utc)``. The helper returns a naive
+  UTC datetime, so the values WebOb exposes are unchanged. See
+  https://github.com/Pylons/webob/issues/473,
+  https://github.com/Pylons/webob/pull/475 and
+  https://github.com/Pylons/webob/pull/480
 
 Backwards Incompatibilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,6 +114,11 @@ Experimental Features
 
 Bugfix
 ~~~~~~
+
+- ``webob.cookies.serialize_cookie_date()`` now converts a timezone-aware
+  ``datetime`` to UTC before serializing it, instead of writing its local
+  wall-clock time out as GMT. Naive datetimes continue to be treated as UTC.
+  See https://github.com/Pylons/webob/pull/475
 
 - Response.content_type now accepts unicode strings on Python 2 and encodes
   them to latin-1. See https://github.com/Pylons/webob/pull/389 and

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except IOError:
     README = CHANGES = ""
 
 testing_extras = [
-    "pytest >= 3.1.0",  # >= 3.1.0 so we can use pytest.param
+    "pytest >= 6.2.0",  # >= 6.2.0 so we can use pytest.MonkeyPatch
     "coverage",
     "pytest-cov",
     "pytest-xdist",

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -10,6 +10,7 @@ import string
 import time
 import warnings
 
+from webob.datetime_utils import utcnow
 from webob.util import bytes_, text_
 
 __all__ = [
@@ -239,7 +240,7 @@ def serialize_cookie_date(v):
         v = timedelta(seconds=v)
 
     if isinstance(v, timedelta):
-        v = datetime.utcnow() + v
+        v = utcnow() + v
 
     if isinstance(v, (datetime, date)):
         v = v.timetuple()

--- a/src/webob/cookies.py
+++ b/src/webob/cookies.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 from collections.abc import MutableMapping
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import hashlib
 import hmac
 import json
@@ -242,8 +242,15 @@ def serialize_cookie_date(v):
     if isinstance(v, timedelta):
         v = utcnow() + v
 
-    if isinstance(v, (datetime, date)):
+    if isinstance(v, datetime):
+        # An aware datetime is converted to UTC; a naive one is assumed to
+        # already be UTC, which is how WebOb has always treated them.
+        if v.tzinfo is not None:
+            v = v.astimezone(timezone.utc)
         v = v.timetuple()
+    elif isinstance(v, date):
+        v = v.timetuple()
+
     r = time.strftime("%%s, %d-%%s-%Y %H:%M:%S GMT", v)
 
     return bytes_(r % (weekdays[v[6]], months[v[1]]), "ascii")

--- a/src/webob/datetime_utils.py
+++ b/src/webob/datetime_utils.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import date, datetime, timedelta, tzinfo
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from email.utils import formatdate, mktime_tz, parsedate_tz
 import time
 
@@ -19,6 +19,7 @@ __all__ = [
     "serialize_date",
     "parse_date_delta",
     "serialize_date_delta",
+    "utcnow",
 ]
 
 _now = datetime.now  # hook point for unit tests
@@ -121,3 +122,10 @@ def serialize_date_delta(value):
         return str(int(value))
     else:
         return serialize_date(value)
+
+
+def utcnow():
+    """
+    replacement of deprecated datetime.datetime.utcnow
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/webob/datetime_utils.py
+++ b/src/webob/datetime_utils.py
@@ -22,7 +22,19 @@ __all__ = [
     "utcnow",
 ]
 
-_now = datetime.now  # hook point for unit tests
+
+def utcnow():
+    """
+    replacement of deprecated datetime.datetime.utcnow
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+# Hook point for unit tests. This is UTC based, not local: the values derived
+# from it are serialized as GMT, so adding a delta to a local "now" would put
+# the result out by the machine's UTC offset. See
+# https://github.com/Pylons/webob/issues/430
+_now = utcnow
 
 
 class _UTC(tzinfo):
@@ -85,6 +97,9 @@ def serialize_date(dt):
         return text_(dt)
 
     if isinstance(dt, timedelta):
+        # The result is serialized as GMT (``usegmt=True`` below) via
+        # ``calendar.timegm``, which reads the time tuple as UTC, so the "now"
+        # the delta is added to must be UTC too.
         dt = _now() + dt
 
     if isinstance(dt, (datetime, date)):
@@ -122,10 +137,3 @@ def serialize_date_delta(value):
         return str(int(value))
     else:
         return serialize_date(value)
-
-
-def utcnow():
-    """
-    replacement of deprecated datetime.datetime.utcnow
-    """
-    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import timedelta
 from hashlib import md5
 import re
 import struct
@@ -13,6 +13,7 @@ from webob.datetime_utils import (
     parse_date_delta,
     serialize_date_delta,
     timedelta_to_seconds,
+    utcnow,
 )
 from webob.descriptors import (
     CHARSET_RE,
@@ -1259,15 +1260,15 @@ class Response:
             cache_control.max_age = 0
             cache_control.post_check = 0
             cache_control.pre_check = 0
-            self.expires = datetime.utcnow()
+            self.expires = utcnow()
 
             if "last-modified" not in self.headers:
-                self.last_modified = datetime.utcnow()
+                self.last_modified = utcnow()
             self.pragma = "no-cache"
         else:
             cache_control.properties.clear()
             cache_control.max_age = seconds
-            self.expires = datetime.utcnow() + timedelta(seconds=seconds)
+            self.expires = utcnow() + timedelta(seconds=seconds)
             self.pragma = None
 
         for name, value in kw.items():

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -1247,6 +1247,10 @@ class Response:
             seconds = timedelta_to_seconds(seconds)
         cache_control = self.cache_control
 
+        # Evaluated once so that ``expires`` and ``last_modified`` cannot
+        # straddle a second boundary and disagree.
+        now = utcnow()
+
         if seconds is None:
             pass
         elif not seconds:
@@ -1260,15 +1264,15 @@ class Response:
             cache_control.max_age = 0
             cache_control.post_check = 0
             cache_control.pre_check = 0
-            self.expires = utcnow()
+            self.expires = now
 
             if "last-modified" not in self.headers:
-                self.last_modified = utcnow()
+                self.last_modified = now
             self.pragma = "no-cache"
         else:
             cache_control.properties.clear()
             cache_control.max_age = seconds
-            self.expires = utcnow() + timedelta(seconds=seconds)
+            self.expires = now + timedelta(seconds=seconds)
             self.pragma = None
 
         for name, value in kw.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 import logging
 import random
 import threading
+import time
 from wsgiref.simple_server import (
     ServerHandler,
     WSGIRequestHandler,
@@ -45,6 +46,25 @@ def _make_test_server(app):
         except BaseException:
             if i == 1:
                 raise
+
+
+@pytest.fixture
+def local_timezone():
+    """Run a block of code under a given process timezone.
+
+    ``monkeypatch`` restores ``TZ`` on exit, but the C library keeps the old
+    zone cached until ``tzset()`` is called again, so we do that afterwards.
+    """
+
+    @contextmanager
+    def _local_timezone(tz):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TZ", tz)
+            time.tzset()
+            yield
+        time.tzset()
+
+    return _local_timezone
 
 
 @pytest.fixture

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,4 +1,6 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta, timezone
+import os
+import time
 
 import pytest
 
@@ -169,6 +171,44 @@ def test_serialize_cookie_date():
     cdate_delta = cookies.serialize_cookie_date(timedelta(seconds=10))
     cdate_int = cookies.serialize_cookie_date(10)
     assert cdate_delta == cdate_int
+
+
+def test_serialize_cookie_date_date():
+    """A plain date has no time component and serializes at midnight."""
+    assert (
+        cookies.serialize_cookie_date(date(2011, 1, 4))
+        == b"Tue, 04-Jan-2011 00:00:00 GMT"
+    )
+
+
+def test_serialize_cookie_date_aware_datetime():
+    """An aware datetime is converted to UTC before being serialized."""
+    aware = datetime(2011, 1, 4, 13, 43, 50, tzinfo=timezone(timedelta(hours=2)))
+    assert cookies.serialize_cookie_date(aware) == b"Tue, 04-Jan-2011 11:43:50 GMT"
+
+
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset() (setting the process timezone) is not available",
+)
+def test_serialize_cookie_date_naive_datetime_is_utc():
+    """
+    A naive datetime is assumed to already be UTC and must not be shifted by
+    the local UTC offset, which is how WebOb has always treated them.
+    """
+    naive = datetime(2011, 1, 4, 13, 43, 50)
+    old_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "America/New_York"
+        time.tzset()
+        result = cookies.serialize_cookie_date(naive)
+    finally:
+        if old_tz is None:
+            del os.environ["TZ"]
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+    assert result == b"Tue, 04-Jan-2011 13:43:50 GMT"
 
 
 def test_serialize_samesite():

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timedelta, timezone
-import os
 import time
 
 import pytest
@@ -191,23 +190,14 @@ def test_serialize_cookie_date_aware_datetime():
     not hasattr(time, "tzset"),
     reason="time.tzset() (setting the process timezone) is not available",
 )
-def test_serialize_cookie_date_naive_datetime_is_utc():
+def test_serialize_cookie_date_naive_datetime_is_utc(local_timezone):
     """
     A naive datetime is assumed to already be UTC and must not be shifted by
     the local UTC offset, which is how WebOb has always treated them.
     """
     naive = datetime(2011, 1, 4, 13, 43, 50)
-    old_tz = os.environ.get("TZ")
-    try:
-        os.environ["TZ"] = "America/New_York"
-        time.tzset()
+    with local_timezone("America/New_York"):
         result = cookies.serialize_cookie_date(naive)
-    finally:
-        if old_tz is None:
-            del os.environ["TZ"]
-        else:
-            os.environ["TZ"] = old_tz
-        time.tzset()
     assert result == b"Tue, 04-Jan-2011 13:43:50 GMT"
 
 

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -1,7 +1,6 @@
 import calendar
 import datetime
 from email.utils import formatdate, parsedate
-import os
 import time
 
 import pytest
@@ -81,7 +80,7 @@ def test_serialize_date():
     not hasattr(time, "tzset"),
     reason="time.tzset() (setting the process timezone) is not available",
 )
-def test_serialize_date_timedelta_is_utc_based():
+def test_serialize_date_timedelta_is_utc_based(local_timezone):
     """A timedelta must be added to *UTC* now, not naive local time.
 
     ``serialize_date`` labels its output as GMT (``usegmt=True``) and builds the
@@ -94,29 +93,20 @@ def test_serialize_date_timedelta_is_utc_based():
     still match the current UTC time (within a small tolerance for the second
     boundary), regardless of the local offset.
     """
-    old_tz = os.environ.get("TZ")
-    try:
-        os.environ["TZ"] = "America/New_York"  # non-UTC, DST-having offset
-        time.tzset()
-
+    # "America/New_York" is a non-UTC, DST-having offset
+    with local_timezone("America/New_York"):
         before = datetime_utils.utcnow()
         header = datetime_utils.serialize_date(datetime.timedelta(seconds=0))
         after = datetime_utils.utcnow()
 
-        header_ts = calendar.timegm(parsedate(header))
-        assert header_ts is not None, header
-        lower = calendar.timegm(before.timetuple()) - 1
-        upper = calendar.timegm(after.timetuple()) + 1
-        assert lower <= header_ts <= upper, (
-            "Expires header %r (%d) is not within [%d, %d] of UTC now; "
-            "it appears to use naive local time" % (header, header_ts, lower, upper)
-        )
-    finally:
-        if old_tz is None:
-            os.environ.pop("TZ", None)
-        else:
-            os.environ["TZ"] = old_tz
-        time.tzset()
+    header_ts = calendar.timegm(parsedate(header))
+    assert header_ts is not None, header
+    lower = calendar.timegm(before.timetuple()) - 1
+    upper = calendar.timegm(after.timetuple()) + 1
+    assert lower <= header_ts <= upper, (
+        "Expires header %r (%d) is not within [%d, %d] of UTC now; "
+        "it appears to use naive local time" % (header, header_ts, lower, upper)
+    )
 
 
 def test_parse_date_delta():
@@ -141,29 +131,20 @@ def test_parse_date_delta():
     not hasattr(time, "tzset"),
     reason="time.tzset() (setting the process timezone) is not available",
 )
-def test_parse_date_delta_is_utc_based():
+def test_parse_date_delta_is_utc_based(local_timezone):
     """
     Delta seconds are resolved against UTC now, not naive local time. Reading
     back a delta-seconds header (such as ``Response.retry_after``) otherwise
     returns an instant off by the local UTC offset. See
     https://github.com/Pylons/webob/issues/430
     """
-    old_tz = os.environ.get("TZ")
-    try:
-        os.environ["TZ"] = "America/New_York"  # non-UTC, DST-having offset
-        time.tzset()
-
+    # "America/New_York" is a non-UTC, DST-having offset
+    with local_timezone("America/New_York"):
         # Note: a falsy value returns None, so the delta must be non-zero.
         delta = datetime.timedelta(seconds=1)
         before = datetime_utils.utcnow() + delta
         ret = datetime_utils.parse_date_delta(1)
         after = datetime_utils.utcnow() + delta
-    finally:
-        if old_tz is None:
-            os.environ.pop("TZ", None)
-        else:
-            os.environ["TZ"] = old_tz
-        time.tzset()
 
     assert before <= ret <= after, (
         "parse_date_delta(1) returned %r, outside [%r, %r]; it appears to use "

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -1,6 +1,8 @@
 import calendar
 import datetime
-from email.utils import formatdate
+from email.utils import formatdate, parsedate
+import os
+import time
 
 import pytest
 
@@ -67,12 +69,54 @@ def test_serialize_date():
     assert isinstance(ret, str)
     assert ret == "Mon, 20 Nov 1995 19:12:08 GMT"
     dt = formatdate(
-        calendar.timegm((datetime.datetime.now() + datetime.timedelta(1)).timetuple()),
+        calendar.timegm((datetime_utils.utcnow() + datetime.timedelta(1)).timetuple()),
         usegmt=True,
     )
     assert dt == datetime_utils.serialize_date(datetime.timedelta(1))
     with pytest.raises(ValueError):
         datetime_utils.serialize_date(None)
+
+
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset() (setting the process timezone) is not available",
+)
+def test_serialize_date_timedelta_is_utc_based():
+    """A timedelta must be added to *UTC* now, not naive local time.
+
+    ``serialize_date`` labels its output as GMT (``usegmt=True``) and builds the
+    epoch with ``calendar.timegm`` (which treats the time tuple as UTC).  If the
+    "now" the delta is added to is naive local time, the resulting header ends
+    up off by the local UTC offset.  See
+    https://github.com/Pylons/webob/issues/430.
+
+    Running under a non-UTC timezone, the serialized zero-delta header must
+    still match the current UTC time (within a small tolerance for the second
+    boundary), regardless of the local offset.
+    """
+    old_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "America/New_York"  # non-UTC, DST-having offset
+        time.tzset()
+
+        before = datetime_utils.utcnow()
+        header = datetime_utils.serialize_date(datetime.timedelta(seconds=0))
+        after = datetime_utils.utcnow()
+
+        header_ts = calendar.timegm(parsedate(header))
+        assert header_ts is not None, header
+        lower = calendar.timegm(before.timetuple()) - 1
+        upper = calendar.timegm(after.timetuple()) + 1
+        assert lower <= header_ts <= upper, (
+            "Expires header %r (%d) is not within [%d, %d] of UTC now; "
+            "it appears to use naive local time" % (header, header_ts, lower, upper)
+        )
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
 
 
 def test_parse_date_delta():
@@ -91,6 +135,40 @@ def test_parse_date_delta():
     with _NowRestorer(WHEN):
         ret = datetime_utils.parse_date_delta(1)
         assert ret == WHEN + datetime.timedelta(0, 1)
+
+
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset() (setting the process timezone) is not available",
+)
+def test_parse_date_delta_is_utc_based():
+    """
+    Delta seconds are resolved against UTC now, not naive local time. Reading
+    back a delta-seconds header (such as ``Response.retry_after``) otherwise
+    returns an instant off by the local UTC offset. See
+    https://github.com/Pylons/webob/issues/430
+    """
+    old_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "America/New_York"  # non-UTC, DST-having offset
+        time.tzset()
+
+        # Note: a falsy value returns None, so the delta must be non-zero.
+        delta = datetime.timedelta(seconds=1)
+        before = datetime_utils.utcnow() + delta
+        ret = datetime_utils.parse_date_delta(1)
+        after = datetime_utils.utcnow() + delta
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+    assert before <= ret <= after, (
+        "parse_date_delta(1) returned %r, outside [%r, %r]; it appears to use "
+        "naive local time" % (ret, before, after)
+    )
 
 
 def test_serialize_date_delta():

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -112,6 +112,15 @@ def test_timedelta_to_seconds():
     assert result == 7464960000
 
 
+def test_utcnow():
+    """utcnow() is a drop-in for the deprecated datetime.utcnow()."""
+    before = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    result = datetime_utils.utcnow()
+    after = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    assert result.tzinfo is None
+    assert before <= result <= after
+
+
 class _NowRestorer:
     def __init__(self, new_now):
         self._new_now = new_now


### PR DESCRIPTION
Combines the three outstanding `utcnow()` / UTC-correctness pull requests into a single branch, with the conflicts resolved and the gaps closed. All three original authors are credited via their own commits.

## Issues

- Fixes #473 — `datetime.datetime.utcnow()` is deprecated as of Python 3.12
- Fixes #430 — setting `Response.expires` via a `timedelta` produces a header off by the local UTC offset

## Supersedes

These are all mutually exclusive — they rewrite the same lines — so none can be merged alongside the others. Their content is included here:

- Supersedes #475 (@jenstroeger) — aware-datetime handling in `serialize_cookie_date`
- Supersedes #480 (@kajinamit) — centralized `utcnow()` helper
- Supersedes #491 (@apoorvdarshan) — UTC-based timedelta date headers

Closing keywords don't apply to PRs, so those three need closing by hand once this lands.

## What's here

**The deprecation (#473).** Takes #480's approach, which @mmerickel favoured in review: a `webob.datetime_utils.utcnow()` helper built on `datetime.now(timezone.utc)` that returns a *naive* UTC datetime. Nothing on the public API surface changes type, which keeps this separate from the tz-aware migration discussed in #473.

**Aware datetimes in cookies.** Takes #475's fix so that a timezone-aware `datetime` passed to `serialize_cookie_date()` is converted to UTC rather than having its local wall-clock time written out as GMT.

One change was needed to make that safe. #475 called `v.astimezone(timezone.utc)` unconditionally, which treats a *naive* datetime as local time and shifts it by the machine's UTC offset — WebOb has always treated naive datetimes as UTC. Under `TZ=America/New_York`:

```
main                 Tue, 04-Jan-2011 13:43:50 GMT
#475 as submitted    Tue, 04-Jan-2011 18:43:50 GMT
```

CI runs in UTC, so this is invisible there. The conversion is now gated on `v.tzinfo is not None`, and `test_serialize_cookie_date_naive_datetime_is_utc` pins it.

**UTC-based timedelta headers (#430).** `datetime_utils._now` was `datetime.now`, i.e. naive *local*. The result is fed to `calendar.timegm` (which reads its argument as UTC) and serialized with `usegmt=True`, so the value came out off by the local UTC offset.

#491 fixed this by adding a `_utcnow = datetime.utcnow` hook — but that would reintroduce the deprecated call this branch removes, in the same module. Instead `_now` is repointed at the `utcnow()` helper. That also fixes a second occurrence of the same bug that #491 doesn't reach: `parse_date_delta()` resolved delta seconds against local time, so reading back `Response.retry_after` returned an instant off by the UTC offset. Keeping the single `_now` hook means the existing `_NowRestorer` tests continue to apply to both call sites.

Verified end-to-end against a real `Response` under `TZ=Europe/Berlin`:

```
                  before              after
real UTC now      06:55:14            06:57:32
r.expires         08:55:14  (+2h)     06:57:32  (0s skew)
r.retry_after     08:55:14  (local)   06:57:32  (UTC)
r.cache_expires   correct             correct
```

## Testing

`tox` across lint, py310–py314, pypy39, pypy310, coverage and docs: all green, 2398 passed / 1 xfailed per interpreter, `coverage --fail-under=100` at exactly 100%.

No `datetime.utcnow()` calls remain in `src/` or `tests/`. The only `DeprecationWarning` the suite still raises is WebOb's own pre-existing `acceptparse.__contains__` one.

New tests: naive/aware/`date` handling in `serialize_cookie_date`, the `utcnow()` helper itself, and tz-sensitive regression tests for both `serialize_date` and `parse_date_delta` (skipped where `time.tzset()` is unavailable).

## Not addressed

`Response.retry_after` still returns a naive datetime on the delta-seconds path while `parse_date` returns an aware UTC one, so comparing the two raises `TypeError`. Reconciling that is the tz-aware migration @mmerickel called "much more controversial" in #473, and is deliberately left alone here.
