### PR TITLE
Drop 0.9-era date helper re-exports from the top-level webob package

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,25 @@ Backwards Incompatibilities
 
 - Drop support for Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8 and 3.9
 
+- The date helpers ``parse_date``, ``parse_date_delta``, ``serialize_date``,
+  ``serialize_date_delta`` and ``timedelta_to_seconds`` are no longer
+  re-exported from the top-level ``webob`` package. They moved to
+  ``webob.datetime_utils`` in WebOb 0.9.7 and have been re-exported from
+  ``webob`` for backwards compatibility ever since, but were never documented
+  or listed in ``webob.__all__``. Import them from ``webob.datetime_utils``
+  instead.
+
+  The ``UTC`` tzinfo object and the ``year``, ``month``, ``week``, ``day``,
+  ``hour``, ``minute`` and ``second`` timedelta constants are unaffected and
+  remain importable from ``webob``.
+
+- ``BaseRequest`` is now listed in ``webob.__all__``. It was already
+  importable from ``webob``, but its absence from ``__all__`` meant type
+  checkers would reject ``from webob import BaseRequest`` once WebOb ships a
+  ``py.typed`` marker.
+
+  See https://github.com/Pylons/webob/issues/457
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/webob/__init__.py
+++ b/src/webob/__init__.py
@@ -1,15 +1,10 @@
-from webob.datetime_utils import (  # noqa: F401
+from webob.datetime_utils import (
     UTC,
     day,
     hour,
     minute,
     month,
-    parse_date,
-    parse_date_delta,
     second,
-    serialize_date,
-    serialize_date_delta,
-    timedelta_to_seconds,
     week,
     year,
 )
@@ -18,6 +13,7 @@ from webob.response import Response
 from webob.util import html_escape
 
 __all__ = [
+    "BaseRequest",
     "Request",
     "Response",
     "UTC",


### PR DESCRIPTION
Drops the five date helpers that the top-level `webob` package has been
re-exporting for backwards compatibility since 0.9.7, and adds `BaseRequest`
to `webob.__all__`.

### Background

`parse_date`, `parse_date_delta`, `serialize_date`, `serialize_date_delta` and
`timedelta_to_seconds` originally lived in `webob/__init__.py`. They moved to
`webob.datetime_utils` in 0196b09 (Nov 2009, version 0.9.7) and the imports
were left behind in `__init__.py` for compatibility. They were never
documented and never listed in `webob.__all__`. Since 2.0 is a major, this
seems like the moment to let them go — they remain available from
`webob.datetime_utils`.

The `UTC` tzinfo object and the `year`/`month`/`week`/`day`/`hour`/`minute`/
`second` timedelta constants are unaffected and remain importable from
`webob`; they're documented and used in `docs/reference.txt`.

### Why now

This came out of #457. Once #477 lands and WebOb ships a `py.typed` marker,
names imported into `__init__.py` but absent from `__all__` stop being
re-exports as far as type checkers are concerned. Installing #477 into a clean
venv and checking a consumer that does `from webob import BaseRequest,
parse_date`:

```
# pyright, default settings — reportPrivateImportUsage is an error at basic level
error: "BaseRequest" is not exported from module "webob"
  Import from "webob.request" instead  [reportPrivateImportUsage]

# mypy --strict
error: Module "webob" does not explicitly export attribute "BaseRequest"  [attr-defined]
```

All six names fail the same way. `BaseRequest` is genuinely public and
documented, so it belongs in `__all__`; the five date helpers are better
dropped than blessed. With this change applied on top of #477, that consumer
file is clean under both pyright and `mypy --strict`.

Note this wouldn't have been caught by #477's own CI: `mypy -p webob` passes
clean there, because `no_implicit_reexport` flags the *importing* module and
nothing inside WebOb imports these from the top-level package. It only
surfaces for consumers, after release. A regression test belongs in the
`tests/mypy/` harness that #477 introduces, so I've suggested it there rather
than adding a mypy dependency here.

### Verification

- Full suite: 2392 passed, 1 xfailed, coverage still 100%
- `from webob import parse_date` now raises `ImportError`;
  `webob.datetime_utils` still exposes all five
- `from webob import *` still supports the documented
  `res.cache_expires(2*day+4*hour)` example
- flake8 clean without the `# noqa: F401`

See #457
