### PR TITLE
Ship .mailmap in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include contributing.md RELEASING.rst
 include pyproject.toml
 include .coveragerc .flake8 tox.ini
 include .readthedocs.yaml
+include .mailmap
 
 global-exclude __pycache__ *.py[cod]
 global-exclude .DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,6 @@ universal = 1
 [metadata]
 license_file = docs/license.txt
 
-[check-manifest]
-ignore =
-    .mailmap
-
 [tool:pytest]
 python_files = test_*.py
 testpaths =


### PR DESCRIPTION
The `.mailmap` that consolidates my commit identities is already in place on
`main`. This just ships it in the sdist rather than telling check-manifest to
ignore it: the `[check-manifest]` stanza is dropped from `setup.cfg` and
`include .mailmap` is added to `MANIFEST.in`, alongside the other root-level
dotfiles we already ship.